### PR TITLE
Add MoonMind intent-driven /chat RAG pipeline

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,10 +7,13 @@ const { connectToDatabase } = require("../mongo");
 const leetcodeRouter = require("../src/routes/leetcode");
 const githubRouter = require("../src/routes/github");
 const refreshRouter = require("../src/routes/refresh");
+const chatRouter = require("../src/routes/chat");
 const swaggerDocs = require("../src/swagger");
 
 const app = express();
 const port = process.env.PORT || 8000;
+
+app.use(express.json({ limit: "1mb" }));
 
 // CORS configuration
 app.use(
@@ -32,6 +35,7 @@ app.get("/", (req, res) => res.redirect("/api/docs"));
 app.use("/api/v1/leetcode", leetcodeRouter);
 app.use("/api/v1/github", githubRouter);
 app.use("/api/v1/refresh", refreshRouter);
+app.use("/chat", chatRouter);
 
 app.listen(port, async () => {
   await connectToDatabase();

--- a/src/moonmind/adapters/openaiClient.js
+++ b/src/moonmind/adapters/openaiClient.js
@@ -1,0 +1,40 @@
+const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || "https://api.openai.com";
+
+async function requestOpenAI(path, body) {
+  const response = await fetch(`${OPENAI_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`OpenAI request failed: ${response.status} ${message}`);
+  }
+
+  return response.json();
+}
+
+async function createChatCompletion({ model, messages, responseFormat, temperature }) {
+  return requestOpenAI("/v1/chat/completions", {
+    model,
+    messages,
+    temperature,
+    response_format: responseFormat,
+  });
+}
+
+async function createEmbedding({ model, input }) {
+  return requestOpenAI("/v1/embeddings", {
+    model,
+    input,
+  });
+}
+
+module.exports = {
+  createChatCompletion,
+  createEmbedding,
+};

--- a/src/moonmind/gate/scopeValidator.js
+++ b/src/moonmind/gate/scopeValidator.js
@@ -1,0 +1,22 @@
+const ALLOWED_INTENTS = new Set([
+  "github_stats",
+  "leetcode_stats",
+  "portfolio_docs",
+  "capabilities",
+]);
+
+function validateScope(intentReport) {
+  if (intentReport.safety?.outOfScope) {
+    return { allowed: false, reason: "out_of_scope_flagged" };
+  }
+
+  if (!ALLOWED_INTENTS.has(intentReport.intent)) {
+    return { allowed: false, reason: "intent_not_allowed" };
+  }
+
+  return { allowed: true };
+}
+
+module.exports = {
+  validateScope,
+};

--- a/src/moonmind/index.js
+++ b/src/moonmind/index.js
@@ -1,0 +1,90 @@
+const crypto = require("crypto");
+const { extractIntent } = require("./intent/intentExtractor");
+const { assertValidIntentReport } = require("./intent/intentValidator");
+const { validateScope } = require("./gate/scopeValidator");
+const { buildExecutionPlan } = require("./planning/planBuilder");
+const { retrieve } = require("./retrieval/retrievalEngine");
+const { rankResults } = require("./ranking/rankingEngine");
+const { decideResponseMode } = require("./response/responseMode");
+const { composeGroundedResponse } = require("./response/responseComposer");
+const { MoonMindError } = require("./utils/errors");
+
+async function runMoonMind({ prompt, sessionId, metadata }) {
+  if (!prompt || typeof prompt !== "string") {
+    throw new MoonMindError("Prompt is required", { code: "INVALID_INPUT" });
+  }
+
+  const requestId = crypto.randomUUID();
+
+  const intentReport = await extractIntent({ prompt, requestId, sessionId });
+  assertValidIntentReport(intentReport);
+
+  if (metadata?.leetcodeUsername && !intentReport.entities.leetcodeUsername) {
+    intentReport.entities.leetcodeUsername = metadata.leetcodeUsername;
+  }
+
+  const scope = validateScope(intentReport);
+  if (!scope.allowed) {
+    return {
+      status: "rejected",
+      reason: scope.reason,
+      intentReport,
+    };
+  }
+
+  const plan = buildExecutionPlan(intentReport);
+
+  if (intentReport.intent === "capabilities") {
+    return {
+      status: "success",
+      mode: "raw",
+      intentReport,
+      plan,
+      data: {
+        supportedIntents: [
+          "github_stats",
+          "leetcode_stats",
+          "portfolio_docs",
+        ],
+        responseModes: ["raw", "grounded"],
+      },
+    };
+  }
+  const retrievalResult = await retrieve(intentReport);
+  const ranked = rankResults(retrievalResult);
+  const responseMode = decideResponseMode(intentReport, ranked);
+
+  if (responseMode === "raw") {
+    return {
+      status: "success",
+      mode: "raw",
+      intentReport,
+      plan,
+      data: ranked.items,
+    };
+  }
+
+  if (responseMode === "unknown") {
+    return {
+      status: "unknown",
+      mode: "unknown",
+      intentReport,
+      plan,
+      message: "unknown",
+    };
+  }
+
+  const responseText = await composeGroundedResponse(intentReport, ranked);
+
+  return {
+    status: "success",
+    mode: "grounded",
+    intentReport,
+    plan,
+    message: responseText,
+  };
+}
+
+module.exports = {
+  runMoonMind,
+};

--- a/src/moonmind/intent/intentExtractor.js
+++ b/src/moonmind/intent/intentExtractor.js
@@ -1,0 +1,59 @@
+const { createChatCompletion } = require("../adapters/openaiClient");
+const { INTENT_REPORT_VERSION } = require("./intentReportSchema");
+
+const INTENT_MODEL = process.env.MOONMIND_INTENT_MODEL || "gpt-4o-mini";
+
+function buildIntentPrompt({ prompt, requestId, sessionId }) {
+  return [
+    {
+      role: "system",
+      content: [
+        "You are a deterministic intent extraction engine.",
+        "Return ONLY a JSON object that matches the provided schema.",
+        "Never include markdown or extra keys.",
+      ].join(" "),
+    },
+    {
+      role: "user",
+      content: [
+        `Request ID: ${requestId}`,
+        `Session ID: ${sessionId ?? "null"}`,
+        `User prompt: ${prompt}`,
+        "Schema requirements:",
+        "- version must be 1.0",
+        "- intent must be one of github_stats, leetcode_stats, portfolio_docs, capabilities, out_of_scope, unknown",
+        "- entities.githubUsername and entities.leetcodeUsername can be null",
+        "- dataSources must list required sources",
+        "- constraints.limit must be null or positive integer",
+        "- response.mode must be raw, grounded, or unknown",
+        "- response.format must be json or text",
+        "- safety.outOfScope must be true only for non-portfolio requests",
+      ].join("\n"),
+    },
+  ];
+}
+
+async function extractIntent({ prompt, requestId, sessionId }) {
+  const messages = buildIntentPrompt({ prompt, requestId, sessionId });
+  const completion = await createChatCompletion({
+    model: INTENT_MODEL,
+    messages,
+    responseFormat: { type: "json_object" },
+    temperature: 0,
+  });
+
+  const content = completion.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("Intent model returned empty response");
+  }
+
+  const report = JSON.parse(content);
+  report.version = INTENT_REPORT_VERSION;
+  report.requestId = requestId;
+  report.sessionId = sessionId ?? null;
+  return report;
+}
+
+module.exports = {
+  extractIntent,
+};

--- a/src/moonmind/intent/intentReportSchema.js
+++ b/src/moonmind/intent/intentReportSchema.js
@@ -1,0 +1,99 @@
+const INTENT_REPORT_VERSION = "1.0";
+
+const intentReportSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "version",
+    "requestId",
+    "intent",
+    "query",
+    "entities",
+    "dataSources",
+    "constraints",
+    "response",
+    "safety",
+    "confidence",
+  ],
+  properties: {
+    version: { type: "string", const: INTENT_REPORT_VERSION },
+    requestId: { type: "string", minLength: 1 },
+    sessionId: { type: ["string", "null"] },
+    intent: {
+      type: "string",
+      enum: [
+        "github_stats",
+        "leetcode_stats",
+        "portfolio_docs",
+        "capabilities",
+        "out_of_scope",
+        "unknown",
+      ],
+    },
+    query: { type: "string", minLength: 1 },
+    entities: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        githubUsername: { type: ["string", "null"] },
+        leetcodeUsername: { type: ["string", "null"] },
+        topics: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["githubUsername", "leetcodeUsername", "topics"],
+    },
+    dataSources: {
+      type: "array",
+      items: {
+        type: "string",
+        enum: [
+          "mongo_github_stats",
+          "leetcode_graphql",
+          "mongo_vector_docs",
+        ],
+      },
+    },
+    constraints: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        timeRange: { type: ["string", "null"] },
+        limit: { type: ["integer", "null"], minimum: 1 },
+        fields: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["timeRange", "limit", "fields"],
+    },
+    response: {
+      type: "object",
+      additionalProperties: false,
+      required: ["mode", "format"],
+      properties: {
+        mode: { type: "string", enum: ["raw", "grounded", "unknown"] },
+        format: { type: "string", enum: ["json", "text"] },
+      },
+    },
+    safety: {
+      type: "object",
+      additionalProperties: false,
+      required: ["outOfScope", "reasons"],
+      properties: {
+        outOfScope: { type: "boolean" },
+        reasons: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+    },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+  },
+};
+
+module.exports = {
+  INTENT_REPORT_VERSION,
+  intentReportSchema,
+};

--- a/src/moonmind/intent/intentValidator.js
+++ b/src/moonmind/intent/intentValidator.js
@@ -1,0 +1,118 @@
+const { intentReportSchema } = require("./intentReportSchema");
+const { MoonMindError } = require("../utils/errors");
+
+const INTENT_ENUM = new Set(intentReportSchema.properties.intent.enum);
+const SOURCE_ENUM = new Set(intentReportSchema.properties.dataSources.items.enum);
+const RESPONSE_MODE_ENUM = new Set(
+  intentReportSchema.properties.response.properties.mode.enum,
+);
+const RESPONSE_FORMAT_ENUM = new Set(
+  intentReportSchema.properties.response.properties.format.enum,
+);
+
+function assertString(value, field) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new MoonMindError(`Invalid ${field}`, { field });
+  }
+}
+
+function assertNullableString(value, field) {
+  if (value !== null && typeof value !== "string") {
+    throw new MoonMindError(`Invalid ${field}`, { field });
+  }
+}
+
+function assertBoolean(value, field) {
+  if (typeof value !== "boolean") {
+    throw new MoonMindError(`Invalid ${field}`, { field });
+  }
+}
+
+function assertArray(value, field) {
+  if (!Array.isArray(value)) {
+    throw new MoonMindError(`Invalid ${field}`, { field });
+  }
+}
+
+function assertValidIntentReport(report) {
+  if (!report || typeof report !== "object") {
+    throw new MoonMindError("Intent report validation failed", { field: "root" });
+  }
+
+  assertString(report.version, "version");
+  if (report.version !== intentReportSchema.properties.version.const) {
+    throw new MoonMindError("Invalid version", { field: "version" });
+  }
+
+  assertString(report.requestId, "requestId");
+  assertNullableString(report.sessionId ?? null, "sessionId");
+
+  if (!INTENT_ENUM.has(report.intent)) {
+    throw new MoonMindError("Invalid intent", { field: "intent" });
+  }
+
+  assertString(report.query, "query");
+
+  if (!report.entities || typeof report.entities !== "object") {
+    throw new MoonMindError("Invalid entities", { field: "entities" });
+  }
+  assertNullableString(report.entities.githubUsername, "entities.githubUsername");
+  assertNullableString(
+    report.entities.leetcodeUsername,
+    "entities.leetcodeUsername",
+  );
+  assertArray(report.entities.topics, "entities.topics");
+
+  assertArray(report.dataSources, "dataSources");
+  report.dataSources.forEach((source) => {
+    if (!SOURCE_ENUM.has(source)) {
+      throw new MoonMindError("Invalid data source", { field: "dataSources" });
+    }
+  });
+
+  if (!report.constraints || typeof report.constraints !== "object") {
+    throw new MoonMindError("Invalid constraints", { field: "constraints" });
+  }
+  assertNullableString(report.constraints.timeRange, "constraints.timeRange");
+  if (
+    report.constraints.limit !== null &&
+    (!Number.isInteger(report.constraints.limit) ||
+      report.constraints.limit < 1)
+  ) {
+    throw new MoonMindError("Invalid constraints.limit", {
+      field: "constraints.limit",
+    });
+  }
+  assertArray(report.constraints.fields, "constraints.fields");
+
+  if (!report.response || typeof report.response !== "object") {
+    throw new MoonMindError("Invalid response", { field: "response" });
+  }
+  if (!RESPONSE_MODE_ENUM.has(report.response.mode)) {
+    throw new MoonMindError("Invalid response.mode", { field: "response.mode" });
+  }
+  if (!RESPONSE_FORMAT_ENUM.has(report.response.format)) {
+    throw new MoonMindError("Invalid response.format", {
+      field: "response.format",
+    });
+  }
+
+  if (!report.safety || typeof report.safety !== "object") {
+    throw new MoonMindError("Invalid safety", { field: "safety" });
+  }
+  assertBoolean(report.safety.outOfScope, "safety.outOfScope");
+  assertArray(report.safety.reasons, "safety.reasons");
+
+  if (typeof report.confidence !== "number") {
+    throw new MoonMindError("Invalid confidence", { field: "confidence" });
+  }
+  if (report.confidence < 0 || report.confidence > 1) {
+    throw new MoonMindError("Invalid confidence", { field: "confidence" });
+  }
+
+  return report;
+}
+
+module.exports = {
+  assertValidIntentReport,
+};

--- a/src/moonmind/planning/planBuilder.js
+++ b/src/moonmind/planning/planBuilder.js
@@ -1,0 +1,26 @@
+function buildExecutionPlan(intentReport) {
+  const plan = [];
+
+  plan.push({ step: "receipt", action: "acknowledge_request" });
+  plan.push({ step: "intent", action: "validate_intent" });
+  plan.push({ step: "scope", action: "scope_gate" });
+
+  if (intentReport.intent === "github_stats") {
+    plan.push({ step: "retrieve", action: "fetch_github_stats" });
+  } else if (intentReport.intent === "leetcode_stats") {
+    plan.push({ step: "retrieve", action: "fetch_leetcode_stats" });
+  } else if (intentReport.intent === "portfolio_docs") {
+    plan.push({ step: "retrieve", action: "vector_search_docs" });
+  } else if (intentReport.intent === "capabilities") {
+    plan.push({ step: "retrieve", action: "none" });
+  }
+
+  plan.push({ step: "rank", action: "mechanical_rank" });
+  plan.push({ step: "respond", action: "compose_response" });
+
+  return plan;
+}
+
+module.exports = {
+  buildExecutionPlan,
+};

--- a/src/moonmind/ranking/rankingEngine.js
+++ b/src/moonmind/ranking/rankingEngine.js
@@ -1,0 +1,18 @@
+function rankResults(retrievalResult) {
+  if (!retrievalResult || !Array.isArray(retrievalResult.items)) {
+    return retrievalResult;
+  }
+
+  if (retrievalResult.type === "portfolio_docs") {
+    const ranked = [...retrievalResult.items].sort(
+      (a, b) => (b.score ?? 0) - (a.score ?? 0),
+    );
+    return { ...retrievalResult, items: ranked };
+  }
+
+  return retrievalResult;
+}
+
+module.exports = {
+  rankResults,
+};

--- a/src/moonmind/response/responseComposer.js
+++ b/src/moonmind/response/responseComposer.js
@@ -1,0 +1,45 @@
+const { createChatCompletion } = require("../adapters/openaiClient");
+
+const RESPONSE_MODEL = process.env.MOONMIND_RESPONSE_MODEL || "gpt-4o-mini";
+
+function buildResponsePrompt(intentReport, retrievalResult) {
+  return [
+    {
+      role: "system",
+      content: [
+        "You are a grounded response composer.",
+        "Use ONLY the provided data payload.",
+        "If data is insufficient, respond with 'unknown'.",
+        "Return plain text only.",
+      ].join(" "),
+    },
+    {
+      role: "user",
+      content: JSON.stringify(
+        {
+          intent: intentReport.intent,
+          query: intentReport.query,
+          data: retrievalResult.items,
+        },
+        null,
+        2,
+      ),
+    },
+  ];
+}
+
+async function composeGroundedResponse(intentReport, retrievalResult) {
+  const messages = buildResponsePrompt(intentReport, retrievalResult);
+  const completion = await createChatCompletion({
+    model: RESPONSE_MODEL,
+    messages,
+    temperature: 0,
+  });
+
+  const content = completion.choices?.[0]?.message?.content?.trim();
+  return content || "unknown";
+}
+
+module.exports = {
+  composeGroundedResponse,
+};

--- a/src/moonmind/response/responseMode.js
+++ b/src/moonmind/response/responseMode.js
@@ -1,0 +1,15 @@
+function decideResponseMode(intentReport, retrievalResult) {
+  if (intentReport.response?.mode === "raw") {
+    return "raw";
+  }
+
+  if (retrievalResult?.missing) {
+    return "unknown";
+  }
+
+  return intentReport.response?.mode || "grounded";
+}
+
+module.exports = {
+  decideResponseMode,
+};

--- a/src/moonmind/retrieval/retrievalEngine.js
+++ b/src/moonmind/retrieval/retrievalEngine.js
@@ -1,0 +1,90 @@
+const axios = require("axios");
+const { getStats } = require("../../../mongo");
+const { vectorSearch } = require("./vectorSearch");
+
+async function fetchGithubStats() {
+  const stats = await getStats();
+  if (!stats?.stats) {
+    return { type: "github_stats", items: [], missing: true };
+  }
+  return { type: "github_stats", items: [stats], missing: false };
+}
+
+async function fetchLeetcodeStats(username) {
+  if (!username) {
+    return { type: "leetcode_stats", items: [], missing: true };
+  }
+
+  const endpoint = "https://leetcode.com/graphql/";
+  const statsQuery = `query userSessionProgress($username: String!) {
+    allQuestionsCount { difficulty count }
+    matchedUser(username: $username) {
+      submitStats {
+        acSubmissionNum { difficulty count submissions }
+      }
+    }
+  }`;
+  const rankingQuery = `query userPublicProfile($username: String!) {
+    matchedUser(username: $username) {
+      profile { ranking }
+    }
+  }`;
+
+  const [response, rankingResponse] = await Promise.all([
+    axios.post(endpoint, {
+      query: statsQuery,
+      variables: { username },
+      operationName: "userSessionProgress",
+    }),
+    axios.post(endpoint, {
+      query: rankingQuery,
+      variables: { username },
+      operationName: "userPublicProfile",
+    }),
+  ]);
+
+  const data = response.data?.data;
+  const ranking = rankingResponse.data?.data;
+
+  if (!data?.matchedUser || !ranking?.matchedUser) {
+    return { type: "leetcode_stats", items: [], missing: true };
+  }
+
+  const payload = {
+    status: "success",
+    totalSolved: data.matchedUser.submitStats.acSubmissionNum[0].count,
+    totalQuestions: data.allQuestionsCount[0].count,
+    easySolved: data.matchedUser.submitStats.acSubmissionNum[1].count,
+    totalEasy: data.allQuestionsCount[1].count,
+    mediumSolved: data.matchedUser.submitStats.acSubmissionNum[2].count,
+    totalMedium: data.allQuestionsCount[2].count,
+    hardSolved: data.matchedUser.submitStats.acSubmissionNum[3].count,
+    totalHard: data.allQuestionsCount[3].count,
+    ranking: ranking.matchedUser.profile.ranking,
+  };
+
+  return { type: "leetcode_stats", items: [payload], missing: false };
+}
+
+async function fetchPortfolioDocs(query, limit) {
+  const docs = await vectorSearch(query, limit ?? 5);
+  return { type: "portfolio_docs", items: docs, missing: docs.length === 0 };
+}
+
+async function retrieve(intentReport) {
+  if (intentReport.intent === "github_stats") {
+    return fetchGithubStats();
+  }
+  if (intentReport.intent === "leetcode_stats") {
+    return fetchLeetcodeStats(intentReport.entities.leetcodeUsername);
+  }
+  if (intentReport.intent === "portfolio_docs") {
+    return fetchPortfolioDocs(intentReport.query, intentReport.constraints.limit);
+  }
+
+  return { type: "none", items: [], missing: false };
+}
+
+module.exports = {
+  retrieve,
+};

--- a/src/moonmind/retrieval/vectorSearch.js
+++ b/src/moonmind/retrieval/vectorSearch.js
@@ -1,0 +1,75 @@
+const { connectToDatabase } = require("../../../mongo");
+const { createEmbedding } = require("../adapters/openaiClient");
+
+const EMBEDDING_MODEL =
+  process.env.MOONMIND_EMBEDDING_MODEL || "text-embedding-3-small";
+const VECTOR_COLLECTION =
+  process.env.MOONMIND_VECTOR_COLLECTION || "moonmind_documents";
+const VECTOR_INDEX =
+  process.env.MOONMIND_VECTOR_INDEX || "moonmind_vector_index";
+const VECTOR_FIELD = process.env.MOONMIND_VECTOR_FIELD || "embedding";
+
+async function embedQuery(query) {
+  const response = await createEmbedding({
+    model: EMBEDDING_MODEL,
+    input: query,
+  });
+  return response.data[0].embedding;
+}
+
+async function vectorSearch(query, limit = 5) {
+  const embedding = await embedQuery(query);
+  const { db } = await connectToDatabase();
+  const collection = db.collection(VECTOR_COLLECTION);
+
+  const pipeline = [
+    {
+      $vectorSearch: {
+        index: VECTOR_INDEX,
+        queryVector: embedding,
+        path: VECTOR_FIELD,
+        numCandidates: Math.max(limit * 5, 25),
+        limit,
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        content: 1,
+        metadata: 1,
+        score: { $meta: "vectorSearchScore" },
+      },
+    },
+  ];
+
+  const results = await collection.aggregate(pipeline).toArray();
+  return results;
+}
+
+const vectorQueryExample = {
+  collection: VECTOR_COLLECTION,
+  pipeline: [
+    {
+      $vectorSearch: {
+        index: VECTOR_INDEX,
+        queryVector: "<embedding-array>",
+        path: VECTOR_FIELD,
+        numCandidates: 50,
+        limit: 5,
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        content: 1,
+        metadata: 1,
+        score: { $meta: "vectorSearchScore" },
+      },
+    },
+  ],
+};
+
+module.exports = {
+  vectorSearch,
+  vectorQueryExample,
+};

--- a/src/moonmind/utils/errors.js
+++ b/src/moonmind/utils/errors.js
@@ -1,0 +1,11 @@
+class MoonMindError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "MoonMindError";
+    this.details = details;
+  }
+}
+
+module.exports = {
+  MoonMindError,
+};

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -1,0 +1,59 @@
+const express = require("express");
+const { runMoonMind } = require("../moonmind");
+const { MoonMindError } = require("../moonmind/utils/errors");
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /chat:
+ *   post:
+ *     summary: MoonMind intent-driven chat
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - prompt
+ *             properties:
+ *               prompt:
+ *                 type: string
+ *               sessionId:
+ *                 type: string
+ *               metadata:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: MoonMind response
+ *       400:
+ *         description: Validation error
+ *       500:
+ *         description: Server error
+ */
+router.post("/", async (req, res) => {
+  try {
+    const result = await runMoonMind({
+      prompt: req.body?.prompt,
+      sessionId: req.body?.sessionId,
+      metadata: req.body?.metadata,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    if (error instanceof MoonMindError) {
+      return res.status(400).json({
+        status: "error",
+        message: error.message,
+        details: error.details,
+      });
+    }
+
+    return res.status(500).json({
+      status: "error",
+      message: "Server Error",
+    });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
### Motivation
- Add a deterministic, intent-driven RAG pipeline to expose safe, grounded queries over existing portfolio data via a single `POST /chat` entrypoint. 
- Enforce early rejection of out-of-scope or invalid requests and separate intent parsing, retrieval, ranking, and response generation steps. 
- Provide a developer-visible, auditable pipeline (intent report schema + plan) rather than a freeform chatbot.

### Description
- Introduce the `src/moonmind` pipeline with modules for intent extraction (`intent/intentExtractor.js`), intent schema (`intent/intentReportSchema.js`), strict validator (`intent/intentValidator.js`), scope gating (`gate/scopeValidator.js`), execution planning (`planning/planBuilder.js`), retrieval (`retrieval/retrievalEngine.js`), vector search (`retrieval/vectorSearch.js`), mechanical ranking (`ranking/rankingEngine.js`), response-mode decision (`response/responseMode.js`), grounded response composition (`response/responseComposer.js`), and error type (`utils/errors.js`).
- Add a lightweight OpenAI adapter `src/moonmind/adapters/openaiClient.js` that calls the OpenAI REST endpoints via `fetch` with two operations exported as `createChatCompletion` and `createEmbedding`. 
- Add the `POST /chat` route at `src/routes/chat.js` and wire JSON body parsing (`app.use(express.json({ limit: "1mb" }))`) and route registration (`app.use("/chat", chatRouter)`) in `api/index.js`. 
- Enforce the full Intent Report schema and validation via `assertValidIntentReport`, perform a deterministic multi-step flow (intent extraction → scope gate → plan → retrieval → mechanical ranking → response mode → grounded answer), and return either `raw`, `unknown`, or `grounded` results; `capabilities` intent returns a raw capabilities payload.

### Testing
- Attempted dependency installation with `npm install`, but the run failed due to an npm registry permission error (`E403`), so automated test runs could not be executed. 
- No automated unit or integration tests were executed in this change; behavior was validated by running file inspections and committing the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885c0d496c8321bcba30f2e5a610b8)