### PR TITLE
Advanced Deterministic Intent Compiler + deterministic FULL_SEARCH pipeline

### DIFF
--- a/src/moonmind/gate/scopeValidator.js
+++ b/src/moonmind/gate/scopeValidator.js
@@ -1,9 +1,15 @@
 function validateScope(intentReport) {
-  if (intentReport.safety?.outOfScope) {
-    return { allowed: false, reason: "out_of_scope" };
+  if (!intentReport.is_in_scope) {
+    return {
+      allowed: false,
+      reason: intentReport.out_of_scope_reason || "out_of_scope",
+      message:
+        intentReport.polite_redirect_message ||
+        "I can only help with portfolio, software, science, or technology topics.",
+    };
   }
 
-  return { allowed: true };
+  return { allowed: true, reason: null, message: null };
 }
 
 module.exports = {

--- a/src/moonmind/index.js
+++ b/src/moonmind/index.js
@@ -1,6 +1,9 @@
 const crypto = require("crypto");
 const { extractIntent } = require("./intent/intentExtractor");
-const { assertValidIntentReport } = require("./intent/intentValidator");
+const {
+  assertValidIntentReport,
+  getExecutionDirective,
+} = require("./intent/intentValidator");
 const { validateScope } = require("./gate/scopeValidator");
 const { buildExecutionPlan } = require("./planning/planBuilder");
 const { retrieve } = require("./retrieval/retrievalEngine");
@@ -15,172 +18,102 @@ const { debugLog, serializeError } = require("./utils/debug");
 
 async function runMoonMind({ prompt, sessionId, metadata }) {
   const requestId = crypto.randomUUID();
-  debugLog("runMoonMind.start", {
-    requestId,
-    sessionId: sessionId ?? null,
-    hasPrompt: typeof prompt === "string",
-    metadataKeys: metadata ? Object.keys(metadata) : [],
-  });
 
   try {
     if (!prompt || typeof prompt !== "string") {
       throw new MoonMindError("Prompt is required", { code: "INVALID_INPUT" });
     }
 
-    debugLog("runMoonMind.extractIntent.start", { requestId });
-    const intentReport = await extractIntent({ prompt, requestId, sessionId });
-    debugLog("runMoonMind.extractIntent.success", {
-      requestId,
-      intentCategory: intentReport.intentCategory,
-      intentSubtype: intentReport.intentSubtype,
-      retrieval: intentReport.execution?.retrieval,
-      responseStyle: intentReport.execution?.responseStyle,
-    });
-
-    debugLog("runMoonMind.intentValidation.start", { requestId });
-    assertValidIntentReport(intentReport);
-    debugLog("runMoonMind.intentValidation.success", { requestId });
-
-    if (metadata?.leetcodeUsername && !intentReport.entities.leetcodeUsername) {
-      intentReport.entities.leetcodeUsername = metadata.leetcodeUsername;
-      debugLog("runMoonMind.entities.enriched", {
-        requestId,
-        field: "entities.leetcodeUsername",
-      });
-    }
-
+    const intentReport = assertValidIntentReport(
+      await extractIntent({ prompt, requestId, sessionId }),
+    );
+    const directive = getExecutionDirective(intentReport);
     const scope = validateScope(intentReport);
-    debugLog("runMoonMind.scope.result", {
-      requestId,
-      allowed: scope.allowed,
-      reason: scope.reason ?? null,
-    });
-
-    const plan = buildExecutionPlan(intentReport);
-    debugLog("runMoonMind.plan.built", {
-      requestId,
-      steps: Array.isArray(plan) ? plan.length : 0,
-    });
+    const plan = buildExecutionPlan(intentReport, directive);
 
     if (!scope.allowed) {
-      debugLog("runMoonMind.exit.scopeRejected", { requestId });
       return {
         status: "rejected",
-        reason: scope.reason,
-        mode: "denial",
+        mode: "redirect",
         intentReport,
         plan,
-        message: intentReport.message || "Unable to assist with that request.",
+        message: scope.message,
       };
     }
 
-    if (intentReport.execution.responseStyle === "greeting") {
-      debugLog("runMoonMind.composeGreeting.start", { requestId });
+    if (!intentReport.logical_validity.is_consistent) {
+      return {
+        status: "rejected",
+        mode: "conflict",
+        intentReport,
+        plan,
+        message: `Request has conflicting constraints: ${intentReport.logical_validity.conflicts.join(
+          "; ",
+        )}`,
+      };
+    }
+
+    if (intentReport.modifiers.is_ambiguous) {
+      return {
+        status: "needs_clarification",
+        mode: "clarification",
+        intentReport,
+        plan,
+        message: intentReport.clarification_question,
+      };
+    }
+
+    if (directive.mode === "greeting") {
       const message = await composeGreeting(prompt);
-      debugLog("runMoonMind.composeGreeting.success", { requestId });
-      return {
-        status: "success",
-        mode: "greeting",
-        intentReport,
-        plan,
-        message,
-      };
+      return { status: "success", mode: "greeting", intentReport, plan, message };
     }
 
-    if (intentReport.execution.responseStyle === "factual") {
-      debugLog("runMoonMind.composeFactual.start", { requestId });
+    if (directive.mode === "factual") {
       const message = await composeFactual(prompt);
-      debugLog("runMoonMind.composeFactual.success", { requestId });
-      return {
-        status: "success",
-        mode: "factual",
-        intentReport,
-        plan,
-        message,
-      };
+      return { status: "success", mode: "factual", intentReport, plan, message };
     }
 
-    if (intentReport.execution.responseStyle === "denial") {
-      debugLog("runMoonMind.exit.denial", { requestId });
+    if (directive.mode === "unsupported") {
       return {
         status: "rejected",
-        mode: "denial",
+        mode: "unsupported",
         intentReport,
         plan,
-        message: intentReport.message,
+        message:
+          intentReport.polite_redirect_message ||
+          "I can help with portfolio, software development, science, technology, GitHub stats, or LeetCode stats.",
       };
     }
 
-    debugLog("runMoonMind.retrieve.start", {
-      requestId,
-      retrieval: intentReport.execution.retrieval,
-    });
-    const retrievalResult = await retrieve(intentReport);
-    debugLog("runMoonMind.retrieve.success", {
-      requestId,
-      retrievalType: retrievalResult?.type,
-      count: retrievalResult?.items?.length ?? 0,
-      missing: Boolean(retrievalResult?.missing),
-    });
-
+    const retrievalResult = await retrieve(intentReport, directive, metadata);
     const ranked = rankResults(retrievalResult);
-    debugLog("runMoonMind.rank.success", {
-      requestId,
-      count: ranked?.items?.length ?? 0,
-      missing: Boolean(ranked?.missing),
-    });
 
     if (ranked?.missing) {
-      debugLog("runMoonMind.exit.unknown", { requestId });
       return {
         status: "unknown",
         mode: "unknown",
         intentReport,
         plan,
         message: "unknown",
-        data: intentReport.execution.responseStyle === "documents" ? [] : undefined,
       };
     }
 
-    debugLog("runMoonMind.composeGrounded.start", {
-      requestId,
-      style: intentReport.execution.responseStyle,
-    });
-    const responseText = await composeGroundedResponse(
-      intentReport,
-      ranked,
-      intentReport.execution.responseStyle,
-    );
-    debugLog("runMoonMind.composeGrounded.success", { requestId });
-
-    if (intentReport.execution.responseStyle === "documents") {
-      return {
-        status: "success",
-        mode: "documents",
-        intentReport,
-        plan,
-        message: responseText,
-        data: ranked.items,
-      };
-    }
-
-    if (intentReport.execution.responseStyle === "summary") {
-      return {
-        status: "success",
-        mode: "summary",
-        intentReport,
-        plan,
-        message: responseText,
-        data: ranked.items,
-      };
-    }
+    const intro = intentReport.modifiers.has_greeting_prefix ? "Great question. " : "";
+    const style =
+      directive.mode === "fetch_documents"
+        ? "documents"
+        : directive.mode === "summarize_aspect"
+          ? "summary"
+          : "grounded";
+    const responseText = await composeGroundedResponse(intentReport, ranked, style);
 
     return {
       status: "success",
-      mode: "grounded",
+      mode: directive.mode,
       intentReport,
       plan,
-      message: responseText,
+      message: `${intro}${responseText}`.trim(),
+      data: ranked.items,
     };
   } catch (error) {
     debugLog("runMoonMind.error", {

--- a/src/moonmind/intent/intentExtractor.js
+++ b/src/moonmind/intent/intentExtractor.js
@@ -1,90 +1,94 @@
 const { createChatCompletion } = require("../adapters/openaiClient");
 const { debugLog, serializeError } = require("../utils/debug");
-const {
-  INTENT_REPORT_VERSION,
-  intentReportSchema,
-} = require("./intentReportSchema");
 
 const INTENT_MODEL = process.env.MOONMIND_INTENT_MODEL || "gpt-4o-mini";
 
-function buildIntentPrompt({ prompt, requestId, sessionId }) {
-  const schemaJson = JSON.stringify(intentReportSchema, null, 2);
-
+function buildIntentPrompt({ prompt }) {
   return [
     {
       role: "system",
       content: [
-        "You are a deterministic intent extraction engine.",
-        "Your sole task is to translate a user prompt into a JSON object that EXACTLY matches the provided schema.",
-        "You must NEVER answer the user directly, explain your reasoning, or include any text outside the JSON object.",
-        "All fields must strictly follow the schema: no extra keys, no missing keys, no type deviations.",
-        "Schema violations are fatal and must not be worked around.",
-        "You may only generate natural language inside the `message` field, and only under the explicit rules provided.",
-        "The `message` field is a brief courtesy response only and must never contain authoritative, exhaustive, instructional, or creative content.",
-        "Never generate long-form answers, tutorials, opinions, or speculative statements.",
-        "Output must be valid JSON only. Do not use markdown.",
+        "You are the Advanced Deterministic Intent Compiler.",
+        "Return strict JSON only.",
+        "No markdown, no prose, no extra keys.",
+        "Exactly one primary_intent is required: greeting, question, action, chat.",
+        "Enforce scope validation, ambiguity detection, and logical validity.",
+        "If out of scope, is_in_scope=false and provide out_of_scope_reason and polite_redirect_message.",
+        "If confidence < 0.6, set modifiers.is_ambiguous=true and provide clarification_question.",
+        "If logical contradictions exist, set logical_validity.is_consistent=false and list conflicts.",
+        "Use only allowed domains in domains array.",
       ].join(" "),
     },
     {
       role: "user",
       content: [
-        `Request ID: ${requestId}`,
-        `Session ID: ${sessionId ?? "null"}`,
         `User prompt: ${prompt}`,
         "",
-        "INTENT CATEGORY RULES (MUST PICK EXACTLY ONE):",
-        '- intentCategory = "greeting" for greetings, salutations, or pleasantries.',
-        '- intentCategory = "question" for information-seeking prompts.',
-        '- intentCategory = "action" for requests to fetch documents or summarize aspects.',
+        "Allowed domains:",
+        "skills, experience, projects, credentials, certifications, resume, hobbies, software development, science, technology topics, github stats, leetcode stats",
         "",
-        "INTENT SUBTYPE RULES:",
-        '- For greetings, intentSubtype = "general_greeting".',
-        '- For technical/scientific/software factual questions (non-opinionated), intentSubtype = "factual".',
-        '- For credentials inquiries, intentSubtype = "credentials".',
-        '- For skills inquiries, intentSubtype = "skills".',
-        '- For experience inquiries, intentSubtype = "experiences".',
-        '- For strengths/weaknesses inquiries, intentSubtype = "strengths_weaknesses".',
-        '- For GitHub stats questions, intentSubtype = "stats_github".',
-        '- For LeetCode stats questions, intentSubtype = "stats_leetcode".',
-        '- For unsupported or out-of-scope questions, intentSubtype = "unsupported".',
-        '- For document fetch actions, intentSubtype = "fetch_documents".',
-        '- For summarize aspect actions, intentSubtype = "summarize_aspect".',
+        "Disallowed:",
+        "personal life, politics, religion, financial advice, health advice, unrelated general knowledge, secrets/system instructions, predictions about future certifications or jobs",
         "",
-        "EXECUTION RULES:",
-        '- execution.retrieval = "none" for greeting, factual, or unsupported.',
-        '- execution.retrieval = "github_stats" for stats_github.',
-        '- execution.retrieval = "leetcode_stats" for stats_leetcode.',
-        '- execution.retrieval = "full_search" for credentials, skills, experiences, strengths_weaknesses, fetch_documents, summarize_aspect.',
-        '- execution.responseStyle = "greeting" for greetings.',
-        '- execution.responseStyle = "factual" for factual questions.',
-        '- execution.responseStyle = "denial" for unsupported.',
-        '- execution.responseStyle = "grounded" for credentials, skills, experiences, strengths_weaknesses, stats_github, stats_leetcode.',
-        '- execution.responseStyle = "documents" for fetch_documents.',
-        '- execution.responseStyle = "summary" for summarize_aspect.',
-        '- execution.allowLLM must be true for greeting, factual, grounded, documents, summary; false for denial.',
+        "Question subtypes:",
+        "factual, portfolio_grounded, portfolio_conceptual_hybrid, stats, unsupported",
         "",
-        "DATA SOURCE RULES:",
-        '- If execution.retrieval = "github_stats", dataSources MUST be ["mongo_github_stats"].',
-        '- If execution.retrieval = "leetcode_stats", dataSources MUST be ["leetcode_graphql"].',
-        '- If execution.retrieval = "full_search", dataSources MUST be ["mongo_vector_docs"].',
-        '- If execution.retrieval = "none", dataSources MUST be [].',
+        "Action subtypes:",
+        "fetch_documents, summarize_aspect, compare_aspects, timeline_view, count_items",
         "",
-        "SAFETY RULES:",
-        '- safety.outOfScope MUST be true ONLY when intentSubtype = "unsupported" due to being out-of-scope.',
-        "- safety.reasons MUST be non-empty ONLY when safety.outOfScope = true.",
-        '- If intentSubtype != "unsupported", safety.outOfScope MUST be false and reasons MUST be empty.',
+        "Greeting subtype:",
+        "standalone_greeting",
         "",
-        "MESSAGE RULES:",
-        '- message MUST be a short, polite, professional, lightly witty denial only when intentSubtype = "unsupported".',
-        '- message MUST be an empty string for all other subtypes (including greetings and factual).',
+        "Chat subtypes:",
+        "portfolio_exploration, unsupported",
         "",
-        "QUERY RULES:",
-        '- query and semanticQuery MUST be concise, retrieval-ready summaries of the user prompt.',
-        '- keywords MUST be a focused list of 1-6 search terms or an empty array when not applicable.',
-        '- filters.topics may mirror entities.topics. filters.documentTypes should be inferred only when explicit.',
-        "",
-        "JSON SCHEMA (VERBATIM — MUST MATCH EXACTLY):",
-        schemaJson,
+        "Required exact JSON shape:",
+        JSON.stringify(
+          {
+            primary_intent: "",
+            subtype: "",
+            confidence: 0,
+            modifiers: {
+              has_greeting_prefix: false,
+              requires_portfolio_grounding: false,
+              requires_conceptual_explanation: false,
+              is_comparison: false,
+              is_multi_domain: false,
+              requires_aggregation: false,
+              is_time_filtered: false,
+              is_ambiguous: false,
+              logical_conflict_detected: false,
+            },
+            is_in_scope: true,
+            out_of_scope_reason: null,
+            polite_redirect_message: null,
+            clarification_question: null,
+            domains: [],
+            filters: {
+              metadata_filters: [],
+              keyword_filters: [],
+              exclusions: [],
+            },
+            boolean_logic: {
+              operator: null,
+              negations: [],
+            },
+            aggregation: {
+              type: "none",
+              group_by_field: null,
+              sort: {
+                field: null,
+                order: null,
+              },
+            },
+            logical_validity: {
+              is_consistent: true,
+              conflicts: [],
+            },
+          },
+          null,
+          2,
+        ),
       ].join("\n"),
     },
   ];
@@ -97,22 +101,12 @@ async function extractIntent({ prompt, requestId, sessionId }) {
     promptLength: typeof prompt === "string" ? prompt.length : 0,
   });
 
-  const messages = buildIntentPrompt({ prompt, requestId, sessionId });
-  debugLog("extractIntent.openai.request", {
-    requestId,
-    model: INTENT_MODEL,
-    messageCount: messages.length,
-  });
-
+  const messages = buildIntentPrompt({ prompt });
   const completion = await createChatCompletion({
     model: INTENT_MODEL,
     messages,
     responseFormat: { type: "json_object" },
     temperature: 0,
-  });
-  debugLog("extractIntent.openai.response", {
-    requestId,
-    choices: completion?.choices?.length ?? 0,
   });
 
   const content = completion.choices?.[0]?.message?.content;
@@ -120,9 +114,8 @@ async function extractIntent({ prompt, requestId, sessionId }) {
     throw new Error("Intent model returned empty response");
   }
 
-  let report;
   try {
-    report = JSON.parse(content);
+    return JSON.parse(content);
   } catch (error) {
     debugLog("extractIntent.parse.error", {
       requestId,
@@ -131,16 +124,6 @@ async function extractIntent({ prompt, requestId, sessionId }) {
     });
     throw error;
   }
-
-  report.version = INTENT_REPORT_VERSION;
-  report.requestId = requestId;
-  report.sessionId = sessionId ?? null;
-  debugLog("extractIntent.success", {
-    requestId,
-    intentCategory: report.intentCategory,
-    intentSubtype: report.intentSubtype,
-  });
-  return report;
 }
 
 module.exports = {

--- a/src/moonmind/intent/intentReportSchema.js
+++ b/src/moonmind/intent/intentReportSchema.js
@@ -1,138 +1,173 @@
-const INTENT_REPORT_VERSION = "2.0";
+const PRIMARY_INTENTS = ["greeting", "question", "action", "chat"];
+const QUESTION_SUBTYPES = [
+  "factual",
+  "portfolio_grounded",
+  "portfolio_conceptual_hybrid",
+  "stats",
+  "unsupported",
+];
+const ACTION_SUBTYPES = [
+  "fetch_documents",
+  "summarize_aspect",
+  "compare_aspects",
+  "timeline_view",
+  "count_items",
+];
+const CHAT_SUBTYPES = ["portfolio_exploration", "unsupported"];
+const GREETING_SUBTYPES = ["standalone_greeting"];
+
+const DOMAIN_ENUM = [
+  "skills",
+  "experience",
+  "projects",
+  "credentials",
+  "certifications",
+  "resume",
+  "hobbies",
+  "software development",
+  "science",
+  "technology topics",
+  "github stats",
+  "leetcode stats",
+];
 
 const intentReportSchema = {
   type: "object",
   additionalProperties: false,
   required: [
-    "version",
-    "requestId",
-    "intentCategory",
-    "intentSubtype",
-    "query",
-    "semanticQuery",
-    "keywords",
-    "filters",
-    "entities",
-    "dataSources",
-    "constraints",
-    "execution",
-    "safety",
-    "message",
+    "primary_intent",
+    "subtype",
     "confidence",
+    "modifiers",
+    "is_in_scope",
+    "out_of_scope_reason",
+    "polite_redirect_message",
+    "clarification_question",
+    "domains",
+    "filters",
+    "boolean_logic",
+    "aggregation",
+    "logical_validity",
   ],
   properties: {
-    version: { type: "string", const: INTENT_REPORT_VERSION },
-    requestId: { type: "string", minLength: 1 },
-    sessionId: { type: ["string", "null"] },
-    intentCategory: {
-      type: "string",
-      enum: ["greeting", "question", "action"],
-    },
-    intentSubtype: {
+    primary_intent: { type: "string", enum: PRIMARY_INTENTS },
+    subtype: {
       type: "string",
       enum: [
-        "general_greeting",
-        "factual",
-        "credentials",
-        "skills",
-        "experiences",
-        "strengths_weaknesses",
-        "stats_github",
-        "stats_leetcode",
-        "unsupported",
-        "fetch_documents",
-        "summarize_aspect",
+        ...QUESTION_SUBTYPES,
+        ...ACTION_SUBTYPES,
+        ...CHAT_SUBTYPES,
+        ...GREETING_SUBTYPES,
       ],
     },
-    query: { type: "string", minLength: 1 },
-    semanticQuery: { type: "string", minLength: 1 },
-    keywords: {
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    modifiers: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "has_greeting_prefix",
+        "requires_portfolio_grounding",
+        "requires_conceptual_explanation",
+        "is_comparison",
+        "is_multi_domain",
+        "requires_aggregation",
+        "is_time_filtered",
+        "is_ambiguous",
+        "logical_conflict_detected",
+      ],
+      properties: {
+        has_greeting_prefix: { type: "boolean" },
+        requires_portfolio_grounding: { type: "boolean" },
+        requires_conceptual_explanation: { type: "boolean" },
+        is_comparison: { type: "boolean" },
+        is_multi_domain: { type: "boolean" },
+        requires_aggregation: { type: "boolean" },
+        is_time_filtered: { type: "boolean" },
+        is_ambiguous: { type: "boolean" },
+        logical_conflict_detected: { type: "boolean" },
+      },
+    },
+    is_in_scope: { type: "boolean" },
+    out_of_scope_reason: { type: ["string", "null"] },
+    polite_redirect_message: { type: ["string", "null"] },
+    clarification_question: { type: ["string", "null"] },
+    domains: {
       type: "array",
-      items: { type: "string" },
+      items: { type: "string", enum: DOMAIN_ENUM },
     },
     filters: {
       type: "object",
       additionalProperties: false,
-      required: ["topics", "documentTypes", "timeRange"],
+      required: ["metadata_filters", "keyword_filters", "exclusions"],
       properties: {
-        topics: {
+        metadata_filters: {
           type: "array",
           items: { type: "string" },
         },
-        documentTypes: {
+        keyword_filters: {
           type: "array",
           items: { type: "string" },
         },
-        timeRange: { type: ["string", "null"] },
+        exclusions: {
+          type: "array",
+          items: { type: "string" },
+        },
       },
     },
-    entities: {
+    boolean_logic: {
       type: "object",
       additionalProperties: false,
+      required: ["operator", "negations"],
       properties: {
-        githubUsername: { type: ["string", "null"] },
-        leetcodeUsername: { type: ["string", "null"] },
-        topics: {
+        operator: { type: ["string", "null"], enum: ["AND", "OR", null] },
+        negations: {
           type: "array",
           items: { type: "string" },
         },
       },
-      required: ["githubUsername", "leetcodeUsername", "topics"],
     },
-    dataSources: {
-      type: "array",
-      items: {
-        type: "string",
-        enum: ["mongo_github_stats", "leetcode_graphql", "mongo_vector_docs"],
-      },
-    },
-    constraints: {
+    aggregation: {
       type: "object",
       additionalProperties: false,
+      required: ["type", "group_by_field", "sort"],
       properties: {
-        timeRange: { type: ["string", "null"] },
-        limit: { type: ["integer", "null"], minimum: 1 },
-        fields: {
-          type: "array",
-          items: { type: "string" },
-        },
-      },
-      required: ["timeRange", "limit", "fields"],
-    },
-    execution: {
-      type: "object",
-      additionalProperties: false,
-      required: ["retrieval", "responseStyle", "allowLLM"],
-      properties: {
-        retrieval: {
+        type: {
           type: "string",
-          enum: ["none", "full_search", "github_stats", "leetcode_stats"],
+          enum: ["none", "compare", "timeline", "group_by", "count"],
         },
-        responseStyle: {
-          type: "string",
-          enum: ["greeting", "factual", "grounded", "denial", "documents", "summary"],
+        group_by_field: { type: ["string", "null"] },
+        sort: {
+          type: "object",
+          additionalProperties: false,
+          required: ["field", "order"],
+          properties: {
+            field: { type: ["string", "null"] },
+            order: { type: ["string", "null"], enum: ["asc", "desc", null] },
+          },
         },
-        allowLLM: { type: "boolean" },
       },
     },
-    safety: {
+    logical_validity: {
       type: "object",
       additionalProperties: false,
-      required: ["outOfScope", "reasons"],
+      required: ["is_consistent", "conflicts"],
       properties: {
-        outOfScope: { type: "boolean" },
-        reasons: {
+        is_consistent: { type: "boolean" },
+        conflicts: {
           type: "array",
           items: { type: "string" },
         },
       },
     },
-    message: { type: "string", maxLength: 240 },
-    confidence: { type: "number", minimum: 0, maximum: 1 },
   },
 };
 
 module.exports = {
-  INTENT_REPORT_VERSION,
+  PRIMARY_INTENTS,
+  QUESTION_SUBTYPES,
+  ACTION_SUBTYPES,
+  CHAT_SUBTYPES,
+  GREETING_SUBTYPES,
+  DOMAIN_ENUM,
   intentReportSchema,
 };

--- a/src/moonmind/intent/intentValidator.js
+++ b/src/moonmind/intent/intentValidator.js
@@ -1,75 +1,56 @@
-const { intentReportSchema } = require("./intentReportSchema");
+const {
+  PRIMARY_INTENTS,
+  QUESTION_SUBTYPES,
+  ACTION_SUBTYPES,
+  CHAT_SUBTYPES,
+  GREETING_SUBTYPES,
+  DOMAIN_ENUM,
+} = require("./intentReportSchema");
 const { MoonMindError } = require("../utils/errors");
 
-const CATEGORY_ENUM = new Set(
-  intentReportSchema.properties.intentCategory.enum,
-);
-const SUBTYPE_ENUM = new Set(intentReportSchema.properties.intentSubtype.enum);
-const SOURCE_ENUM = new Set(intentReportSchema.properties.dataSources.items.enum);
-const EXECUTION_RETRIEVAL_ENUM = new Set(
-  intentReportSchema.properties.execution.properties.retrieval.enum,
-);
-const EXECUTION_RESPONSE_ENUM = new Set(
-  intentReportSchema.properties.execution.properties.responseStyle.enum,
-);
+const TOP_LEVEL_KEYS = [
+  "primary_intent",
+  "subtype",
+  "confidence",
+  "modifiers",
+  "is_in_scope",
+  "out_of_scope_reason",
+  "polite_redirect_message",
+  "clarification_question",
+  "domains",
+  "filters",
+  "boolean_logic",
+  "aggregation",
+  "logical_validity",
+];
 
-const SUBTYPE_BY_CATEGORY = {
-  greeting: new Set(["general_greeting"]),
-  question: new Set([
-    "factual",
-    "credentials",
-    "skills",
-    "experiences",
-    "strengths_weaknesses",
-    "stats_github",
-    "stats_leetcode",
-    "unsupported",
-  ]),
-  action: new Set(["fetch_documents", "summarize_aspect"]),
-};
+const MODIFIER_KEYS = [
+  "has_greeting_prefix",
+  "requires_portfolio_grounding",
+  "requires_conceptual_explanation",
+  "is_comparison",
+  "is_multi_domain",
+  "requires_aggregation",
+  "is_time_filtered",
+  "is_ambiguous",
+  "logical_conflict_detected",
+];
 
-const RETRIEVAL_BY_SUBTYPE = {
-  general_greeting: "none",
-  factual: "none",
-  credentials: "full_search",
-  skills: "full_search",
-  experiences: "full_search",
-  strengths_weaknesses: "full_search",
-  stats_github: "github_stats",
-  stats_leetcode: "leetcode_stats",
-  unsupported: "none",
-  fetch_documents: "full_search",
-  summarize_aspect: "full_search",
-};
+function assertExactKeys(obj, keys, field) {
+  const actual = Object.keys(obj || {});
+  if (actual.length !== keys.length || keys.some((key) => !actual.includes(key))) {
+    throw new MoonMindError(`Invalid ${field} keys`, { field });
+  }
+}
 
-const RESPONSE_STYLE_BY_SUBTYPE = {
-  general_greeting: "greeting",
-  factual: "factual",
-  credentials: "grounded",
-  skills: "grounded",
-  experiences: "grounded",
-  strengths_weaknesses: "grounded",
-  stats_github: "grounded",
-  stats_leetcode: "grounded",
-  unsupported: "denial",
-  fetch_documents: "documents",
-  summarize_aspect: "summary",
-};
-
-function assertString(value, field) {
-  if (typeof value !== "string" || value.length === 0) {
+function assertType(value, type, field) {
+  if (typeof value !== type) {
     throw new MoonMindError(`Invalid ${field}`, { field });
   }
 }
 
-function assertNullableString(value, field) {
+function assertStringOrNull(value, field) {
   if (value !== null && typeof value !== "string") {
-    throw new MoonMindError(`Invalid ${field}`, { field });
-  }
-}
-
-function assertBoolean(value, field) {
-  if (typeof value !== "boolean") {
     throw new MoonMindError(`Invalid ${field}`, { field });
   }
 }
@@ -80,166 +61,185 @@ function assertArray(value, field) {
   }
 }
 
+function assertBoolean(value, field) {
+  if (typeof value !== "boolean") {
+    throw new MoonMindError(`Invalid ${field}`, { field });
+  }
+}
+
+function assertSubtype(primaryIntent, subtype) {
+  if (primaryIntent === "greeting" && !GREETING_SUBTYPES.includes(subtype)) {
+    throw new MoonMindError("Invalid subtype for greeting", { field: "subtype" });
+  }
+  if (primaryIntent === "question" && !QUESTION_SUBTYPES.includes(subtype)) {
+    throw new MoonMindError("Invalid subtype for question", { field: "subtype" });
+  }
+  if (primaryIntent === "action" && !ACTION_SUBTYPES.includes(subtype)) {
+    throw new MoonMindError("Invalid subtype for action", { field: "subtype" });
+  }
+  if (primaryIntent === "chat" && !CHAT_SUBTYPES.includes(subtype)) {
+    throw new MoonMindError("Invalid subtype for chat", { field: "subtype" });
+  }
+}
+
 function assertValidIntentReport(report) {
-  if (!report || typeof report !== "object") {
+  if (!report || typeof report !== "object" || Array.isArray(report)) {
     throw new MoonMindError("Intent report validation failed", { field: "root" });
   }
 
-  assertString(report.version, "version");
-  if (report.version !== intentReportSchema.properties.version.const) {
-    throw new MoonMindError("Invalid version", { field: "version" });
+  assertExactKeys(report, TOP_LEVEL_KEYS, "root");
+
+  if (!PRIMARY_INTENTS.includes(report.primary_intent)) {
+    throw new MoonMindError("Invalid primary_intent", { field: "primary_intent" });
+  }
+  assertType(report.subtype, "string", "subtype");
+  assertSubtype(report.primary_intent, report.subtype);
+
+  assertType(report.confidence, "number", "confidence");
+  if (report.confidence < 0 || report.confidence > 1) {
+    throw new MoonMindError("Invalid confidence range", { field: "confidence" });
   }
 
-  assertString(report.requestId, "requestId");
-  assertNullableString(report.sessionId ?? null, "sessionId");
+  if (!report.modifiers || typeof report.modifiers !== "object") {
+    throw new MoonMindError("Invalid modifiers", { field: "modifiers" });
+  }
+  assertExactKeys(report.modifiers, MODIFIER_KEYS, "modifiers");
+  MODIFIER_KEYS.forEach((key) => assertBoolean(report.modifiers[key], `modifiers.${key}`));
 
-  if (!CATEGORY_ENUM.has(report.intentCategory)) {
-    throw new MoonMindError("Invalid intentCategory", { field: "intentCategory" });
-  }
-  if (!SUBTYPE_ENUM.has(report.intentSubtype)) {
-    throw new MoonMindError("Invalid intentSubtype", { field: "intentSubtype" });
-  }
-  const allowedSubtypes = SUBTYPE_BY_CATEGORY[report.intentCategory];
-  if (!allowedSubtypes?.has(report.intentSubtype)) {
-    throw new MoonMindError("intentSubtype does not match category", {
-      field: "intentSubtype",
-    });
-  }
+  assertBoolean(report.is_in_scope, "is_in_scope");
+  assertStringOrNull(report.out_of_scope_reason, "out_of_scope_reason");
+  assertStringOrNull(report.polite_redirect_message, "polite_redirect_message");
+  assertStringOrNull(report.clarification_question, "clarification_question");
 
-  assertString(report.query, "query");
-  assertString(report.semanticQuery, "semanticQuery");
-  assertArray(report.keywords, "keywords");
+  assertArray(report.domains, "domains");
+  report.domains.forEach((domain) => {
+    if (typeof domain !== "string" || !DOMAIN_ENUM.includes(domain)) {
+      throw new MoonMindError("Invalid domain", { field: "domains" });
+    }
+  });
 
   if (!report.filters || typeof report.filters !== "object") {
     throw new MoonMindError("Invalid filters", { field: "filters" });
   }
-  assertArray(report.filters.topics, "filters.topics");
-  assertArray(report.filters.documentTypes, "filters.documentTypes");
-  assertNullableString(report.filters.timeRange, "filters.timeRange");
+  assertExactKeys(report.filters, ["metadata_filters", "keyword_filters", "exclusions"], "filters");
+  assertArray(report.filters.metadata_filters, "filters.metadata_filters");
+  assertArray(report.filters.keyword_filters, "filters.keyword_filters");
+  assertArray(report.filters.exclusions, "filters.exclusions");
 
-  if (!report.entities || typeof report.entities !== "object") {
-    throw new MoonMindError("Invalid entities", { field: "entities" });
+  if (!report.boolean_logic || typeof report.boolean_logic !== "object") {
+    throw new MoonMindError("Invalid boolean_logic", { field: "boolean_logic" });
   }
-  assertNullableString(report.entities.githubUsername, "entities.githubUsername");
-  assertNullableString(
-    report.entities.leetcodeUsername,
-    "entities.leetcodeUsername",
-  );
-  assertArray(report.entities.topics, "entities.topics");
+  assertExactKeys(report.boolean_logic, ["operator", "negations"], "boolean_logic");
+  if (!["AND", "OR", null].includes(report.boolean_logic.operator)) {
+    throw new MoonMindError("Invalid boolean_logic.operator", { field: "boolean_logic.operator" });
+  }
+  assertArray(report.boolean_logic.negations, "boolean_logic.negations");
 
-  assertArray(report.dataSources, "dataSources");
-  report.dataSources.forEach((source) => {
-    if (!SOURCE_ENUM.has(source)) {
-      throw new MoonMindError("Invalid data source", { field: "dataSources" });
-    }
-  });
-
-  if (!report.constraints || typeof report.constraints !== "object") {
-    throw new MoonMindError("Invalid constraints", { field: "constraints" });
+  if (!report.aggregation || typeof report.aggregation !== "object") {
+    throw new MoonMindError("Invalid aggregation", { field: "aggregation" });
   }
-  assertNullableString(report.constraints.timeRange, "constraints.timeRange");
-  if (
-    report.constraints.limit !== null &&
-    (!Number.isInteger(report.constraints.limit) ||
-      report.constraints.limit < 1)
-  ) {
-    throw new MoonMindError("Invalid constraints.limit", {
-      field: "constraints.limit",
-    });
+  assertExactKeys(report.aggregation, ["type", "group_by_field", "sort"], "aggregation");
+  if (!["none", "compare", "timeline", "group_by", "count"].includes(report.aggregation.type)) {
+    throw new MoonMindError("Invalid aggregation.type", { field: "aggregation.type" });
   }
-  assertArray(report.constraints.fields, "constraints.fields");
-
-  if (!report.execution || typeof report.execution !== "object") {
-    throw new MoonMindError("Invalid execution", { field: "execution" });
+  assertStringOrNull(report.aggregation.group_by_field, "aggregation.group_by_field");
+  if (!report.aggregation.sort || typeof report.aggregation.sort !== "object") {
+    throw new MoonMindError("Invalid aggregation.sort", { field: "aggregation.sort" });
   }
-  if (!EXECUTION_RETRIEVAL_ENUM.has(report.execution.retrieval)) {
-    throw new MoonMindError("Invalid execution.retrieval", {
-      field: "execution.retrieval",
-    });
-  }
-  if (!EXECUTION_RESPONSE_ENUM.has(report.execution.responseStyle)) {
-    throw new MoonMindError("Invalid execution.responseStyle", {
-      field: "execution.responseStyle",
-    });
-  }
-  assertBoolean(report.execution.allowLLM, "execution.allowLLM");
-
-  const expectedRetrieval = RETRIEVAL_BY_SUBTYPE[report.intentSubtype];
-  if (expectedRetrieval !== report.execution.retrieval) {
-    throw new MoonMindError("execution.retrieval mismatch", {
-      field: "execution.retrieval",
-    });
-  }
-  const expectedResponse = RESPONSE_STYLE_BY_SUBTYPE[report.intentSubtype];
-  if (expectedResponse !== report.execution.responseStyle) {
-    throw new MoonMindError("execution.responseStyle mismatch", {
-      field: "execution.responseStyle",
-    });
+  assertExactKeys(report.aggregation.sort, ["field", "order"], "aggregation.sort");
+  assertStringOrNull(report.aggregation.sort.field, "aggregation.sort.field");
+  if (!["asc", "desc", null].includes(report.aggregation.sort.order)) {
+    throw new MoonMindError("Invalid aggregation.sort.order", { field: "aggregation.sort.order" });
   }
 
-  if (!report.safety || typeof report.safety !== "object") {
-    throw new MoonMindError("Invalid safety", { field: "safety" });
+  if (!report.logical_validity || typeof report.logical_validity !== "object") {
+    throw new MoonMindError("Invalid logical_validity", { field: "logical_validity" });
   }
-  assertBoolean(report.safety.outOfScope, "safety.outOfScope");
-  assertArray(report.safety.reasons, "safety.reasons");
+  assertExactKeys(report.logical_validity, ["is_consistent", "conflicts"], "logical_validity");
+  assertBoolean(report.logical_validity.is_consistent, "logical_validity.is_consistent");
+  assertArray(report.logical_validity.conflicts, "logical_validity.conflicts");
 
-  if (report.intentSubtype === "unsupported") {
-    if (report.safety.outOfScope && report.safety.reasons.length === 0) {
-      throw new MoonMindError("Missing safety reasons", {
-        field: "safety.reasons",
+  if (!report.is_in_scope) {
+    if (!report.out_of_scope_reason || !report.polite_redirect_message) {
+      throw new MoonMindError("Out of scope responses require reason and redirect", {
+        field: "is_in_scope",
       });
     }
-  } else {
-    if (report.safety.outOfScope || report.safety.reasons.length > 0) {
-      throw new MoonMindError("Unexpected safety flags", { field: "safety" });
-    }
-  }
-
-  if (typeof report.message !== "string") {
-    throw new MoonMindError("Invalid message", { field: "message" });
-  }
-  if (report.intentSubtype === "unsupported" && report.message.length === 0) {
-    throw new MoonMindError("Message required for unsupported", {
-      field: "message",
+  } else if (report.out_of_scope_reason !== null || report.polite_redirect_message !== null) {
+    throw new MoonMindError("In-scope responses must not include out-of-scope payload", {
+      field: "is_in_scope",
     });
   }
-  if (report.intentSubtype !== "unsupported" && report.message.length > 0) {
-    throw new MoonMindError("Message must be empty", { field: "message" });
-  }
 
-  if (typeof report.confidence !== "number") {
-    throw new MoonMindError("Invalid confidence", { field: "confidence" });
-  }
-  if (report.confidence < 0 || report.confidence > 1) {
-    throw new MoonMindError("Invalid confidence", { field: "confidence" });
-  }
-
-  const expectedSources = (() => {
-    switch (report.execution.retrieval) {
-      case "github_stats":
-        return ["mongo_github_stats"];
-      case "leetcode_stats":
-        return ["leetcode_graphql"];
-      case "full_search":
-        return ["mongo_vector_docs"];
-      case "none":
-      default:
-        return [];
+  if (report.confidence < 0.6) {
+    if (!report.modifiers.is_ambiguous || !report.clarification_question) {
+      throw new MoonMindError("Ambiguous reports must include clarification question", {
+        field: "clarification_question",
+      });
     }
-  })();
-
-  if (report.dataSources.length !== expectedSources.length) {
-    throw new MoonMindError("Invalid dataSources", { field: "dataSources" });
+  } else if (report.modifiers.is_ambiguous && !report.clarification_question) {
+    throw new MoonMindError("Ambiguous flag requires clarification question", {
+      field: "clarification_question",
+    });
   }
-  expectedSources.forEach((source) => {
-    if (!report.dataSources.includes(source)) {
-      throw new MoonMindError("Invalid dataSources", { field: "dataSources" });
+
+  if (!report.logical_validity.is_consistent) {
+    if (!report.modifiers.logical_conflict_detected) {
+      throw new MoonMindError("Conflict flag required for inconsistent reports", {
+        field: "modifiers.logical_conflict_detected",
+      });
     }
-  });
+    if (report.logical_validity.conflicts.length === 0) {
+      throw new MoonMindError("Conflicts required when inconsistent", {
+        field: "logical_validity.conflicts",
+      });
+    }
+  }
 
   return report;
 }
 
+function getExecutionDirective(report) {
+  if (!report.is_in_scope) {
+    return { mode: "redirect", retrieval: "none" };
+  }
+  if (!report.logical_validity.is_consistent) {
+    return { mode: "conflict", retrieval: "none" };
+  }
+  if (report.modifiers.is_ambiguous) {
+    return { mode: "clarification", retrieval: "none" };
+  }
+  if (report.primary_intent === "greeting") {
+    return { mode: "greeting", retrieval: "none" };
+  }
+  if (report.primary_intent === "question") {
+    if (report.subtype === "factual") {
+      return { mode: "factual", retrieval: "none" };
+    }
+    if (report.subtype === "unsupported") {
+      return { mode: "unsupported", retrieval: "none" };
+    }
+    if (report.subtype === "stats") {
+      const isLeetcode = report.domains.includes("leetcode stats");
+      return { mode: "stats", retrieval: isLeetcode ? "leetcode_stats" : "github_stats" };
+    }
+    return { mode: "grounded", retrieval: "full_search" };
+  }
+  if (report.primary_intent === "action") {
+    return { mode: report.subtype, retrieval: "full_search" };
+  }
+  if (report.primary_intent === "chat") {
+    if (report.subtype === "unsupported") {
+      return { mode: "unsupported", retrieval: "none" };
+    }
+    return { mode: "chat", retrieval: "full_search" };
+  }
+  throw new MoonMindError("Unable to derive execution directive", {
+    field: "primary_intent",
+  });
+}
+
 module.exports = {
   assertValidIntentReport,
+  getExecutionDirective,
 };

--- a/src/moonmind/planning/planBuilder.js
+++ b/src/moonmind/planning/planBuilder.js
@@ -1,25 +1,28 @@
-function buildExecutionPlan(intentReport) {
+function buildExecutionPlan(intentReport, directive) {
   const plan = [];
 
   plan.push({ step: "receipt", action: "acknowledge_request" });
-  plan.push({ step: "intent", action: "validate_intent" });
+  plan.push({ step: "intent", action: "compile_intent" });
   plan.push({ step: "scope", action: "scope_gate" });
+  plan.push({ step: "validity", action: "logical_consistency_gate" });
+  plan.push({ step: "ambiguity", action: "clarification_gate" });
 
-  if (intentReport.execution.retrieval === "github_stats") {
+  if (directive.retrieval === "github_stats") {
     plan.push({ step: "retrieve", action: "fetch_github_stats" });
-  } else if (intentReport.execution.retrieval === "leetcode_stats") {
+  } else if (directive.retrieval === "leetcode_stats") {
     plan.push({ step: "retrieve", action: "fetch_leetcode_stats" });
-  } else if (intentReport.execution.retrieval === "full_search") {
-    plan.push({ step: "retrieve", action: "metadata_search" });
-    plan.push({ step: "retrieve", action: "keyword_search" });
-    plan.push({ step: "retrieve", action: "semantic_search" });
-    plan.push({ step: "rank", action: "rerank" });
+  } else if (directive.retrieval === "full_search") {
+    plan.push({ step: "retrieve", action: "metadata_filters" });
+    plan.push({ step: "retrieve", action: "keyword_filters" });
+    plan.push({ step: "retrieve", action: "boolean_logic" });
+    plan.push({ step: "retrieve", action: "semantic_vector_search" });
+    plan.push({ step: "rank", action: "deterministic_reranking" });
     plan.push({ step: "select", action: "top_n" });
   } else {
     plan.push({ step: "retrieve", action: "none" });
   }
 
-  plan.push({ step: "respond", action: "compose_response" });
+  plan.push({ step: "respond", action: directive.mode });
 
   return plan;
 }

--- a/src/moonmind/response/responseComposer.js
+++ b/src/moonmind/response/responseComposer.js
@@ -63,9 +63,9 @@ function buildGroundedPrompt(intentReport, retrievalResult, style) {
       role: "user",
       content: JSON.stringify(
         {
-          intentCategory: intentReport.intentCategory,
-          intentSubtype: intentReport.intentSubtype,
-          query: intentReport.query,
+          primary_intent: intentReport.primary_intent,
+          subtype: intentReport.subtype,
+          domains: intentReport.domains,
           data: retrievalResult.items,
         },
         null,
@@ -118,7 +118,7 @@ async function composeGroundedResponse(intentReport, retrievalResult, style) {
     model: RESPONSE_MODEL,
     style,
     itemCount: retrievalResult?.items?.length ?? 0,
-    intentSubtype: intentReport?.intentSubtype,
+    subtype: intentReport?.subtype,
   });
   const messages = buildGroundedPrompt(intentReport, retrievalResult, style);
   const completion = await createChatCompletion({

--- a/src/moonmind/retrieval/fullSearch.js
+++ b/src/moonmind/retrieval/fullSearch.js
@@ -6,8 +6,8 @@ const VECTOR_COLLECTION =
   process.env.MOONMIND_VECTOR_COLLECTION || "moonmind_documents";
 
 const SCORE_WEIGHTS = {
-  semantic: 0.7,
-  keyword: 0.2,
+  semantic: 0.65,
+  keyword: 0.25,
   metadata: 0.1,
 };
 
@@ -24,78 +24,81 @@ function normalizeDoc(doc) {
   };
 }
 
-function buildMetadataQuery(filters) {
-  const clauses = [];
-
-  if (filters.topics?.length) {
-    clauses.push({ "metadata.topics": { $in: filters.topics } });
-    clauses.push({ "metadata.tags": { $in: filters.topics } });
-    clauses.push({ "metadata.category": { $in: filters.topics } });
-  }
-
-  if (filters.documentTypes?.length) {
-    clauses.push({ "metadata.type": { $in: filters.documentTypes } });
-    clauses.push({ "metadata.documentType": { $in: filters.documentTypes } });
-  }
-
-  if (filters.timeRange) {
-    clauses.push({ "metadata.timeRange": filters.timeRange });
-    clauses.push({ "metadata.date": filters.timeRange });
-    clauses.push({ "metadata.year": filters.timeRange });
-  }
-
-  if (clauses.length === 0) {
+function buildMetadataQuery(metadataFilters) {
+  if (!metadataFilters?.length) {
     return null;
   }
 
-  return { $or: clauses };
-}
-
-async function metadataSearch({ filters, limit }) {
-  const query = buildMetadataQuery(filters);
-  if (!query) {
-    debugLog("fullSearch.metadata.skip.noQuery");
-    return [];
-  }
-
-  const { db } = await connectToDatabase();
-  const collection = db.collection(VECTOR_COLLECTION);
-
-  const results = await collection
-    .find(query, { projection: { content: 1, metadata: 1 } })
-    .limit(Math.max(limit * 3, 10))
-    .toArray();
-
-  debugLog("fullSearch.metadata.results", { count: results.length });
-  return results.map((doc) => ({ ...normalizeDoc(doc), score: 0.5 }));
-}
-
-function buildKeywordQuery(keywords) {
-  if (!keywords?.length) {
-    return null;
-  }
-
-  const clauses = [];
-  keywords.forEach((keyword) => {
-    const safeKeyword = escapeRegex(keyword);
-    const regex = { $regex: safeKeyword, $options: "i" };
-    clauses.push({ content: regex });
-    clauses.push({ "metadata.title": regex });
-    clauses.push({ "metadata.summary": regex });
-    clauses.push({ "metadata.tags": regex });
+  const clauses = metadataFilters.map((filter) => {
+    const safe = escapeRegex(filter);
+    const regex = { $regex: safe, $options: "i" };
+    return {
+      $or: [
+        { "metadata.topics": regex },
+        { "metadata.tags": regex },
+        { "metadata.category": regex },
+        { "metadata.type": regex },
+      ],
+    };
   });
 
-  if (clauses.length === 0) {
+  return clauses.length ? { $and: clauses } : null;
+}
+
+function buildKeywordQuery(keywordFilters) {
+  if (!keywordFilters?.length) {
     return null;
   }
 
-  return { $or: clauses };
+  const clauses = keywordFilters.map((keyword) => {
+    const safe = escapeRegex(keyword);
+    const regex = { $regex: safe, $options: "i" };
+    return {
+      $or: [
+        { content: regex },
+        { "metadata.title": regex },
+        { "metadata.summary": regex },
+        { "metadata.tags": regex },
+      ],
+    };
+  });
+
+  return clauses.length ? { $or: clauses } : null;
 }
 
-async function keywordSearch({ keywords, limit }) {
-  const query = buildKeywordQuery(keywords);
-  if (!query) {
-    debugLog("fullSearch.keyword.skip.noQuery");
+function applyBooleanLogic({ metadataQuery, keywordQuery, operator, negations }) {
+  const conditions = [metadataQuery, keywordQuery].filter(Boolean);
+  let query = conditions.length
+    ? operator === "OR"
+      ? { $or: conditions }
+      : { $and: conditions }
+    : {};
+
+  if (negations?.length) {
+    const negationClauses = negations.map((term) => {
+      const safe = escapeRegex(term);
+      const regex = { $regex: safe, $options: "i" };
+      return {
+        $or: [
+          { content: regex },
+          { "metadata.title": regex },
+          { "metadata.summary": regex },
+          { "metadata.tags": regex },
+        ],
+      };
+    });
+
+    query = {
+      ...query,
+      $nor: negationClauses,
+    };
+  }
+
+  return query;
+}
+
+async function mongoSearch(query, limit) {
+  if (!query || Object.keys(query).length === 0) {
     return [];
   }
 
@@ -104,115 +107,103 @@ async function keywordSearch({ keywords, limit }) {
 
   const results = await collection
     .find(query, { projection: { content: 1, metadata: 1 } })
-    .limit(Math.max(limit * 4, 12))
+    .limit(limit)
     .toArray();
 
-  debugLog("fullSearch.keyword.results", { count: results.length });
-  return results.map((doc) => ({ ...normalizeDoc(doc), score: 1 }));
+  return results.map((doc) => normalizeDoc(doc));
 }
 
 function mergeResults({ metadataResults, keywordResults, semanticResults }) {
   const merged = new Map();
 
-  const applyResults = (docs, source) => {
+  const apply = (docs, source) => {
     docs.forEach((doc) => {
       const key = String(doc._id);
-      const existing = merged.get(key) ?? {
+      const existing = merged.get(key) || {
         _id: doc._id,
         content: doc.content,
         metadata: doc.metadata,
-        stageScores: {
-          semantic: 0,
-          keyword: 0,
-          metadata: 0,
-        },
+        stageScores: { semantic: 0, keyword: 0, metadata: 0 },
       };
-
-      if (source === "semantic") {
-        existing.stageScores.semantic = Math.max(
-          existing.stageScores.semantic,
-          doc.score ?? 0,
-        );
-      }
-      if (source === "keyword") {
-        existing.stageScores.keyword = Math.max(
-          existing.stageScores.keyword,
-          doc.score ?? 0,
-        );
-      }
-      if (source === "metadata") {
-        existing.stageScores.metadata = Math.max(
-          existing.stageScores.metadata,
-          doc.score ?? 0,
-        );
-      }
-
+      existing.stageScores[source] = Math.max(existing.stageScores[source], doc.score ?? 1);
       merged.set(key, existing);
     });
   };
 
-  applyResults(metadataResults, "metadata");
-  applyResults(keywordResults, "keyword");
-  applyResults(semanticResults, "semantic");
+  apply(metadataResults, "metadata");
+  apply(keywordResults, "keyword");
+  apply(semanticResults, "semantic");
 
-  return Array.from(merged.values()).map((doc) => {
-    const combinedScore =
+  return Array.from(merged.values()).map((doc) => ({
+    _id: doc._id,
+    content: doc.content,
+    metadata: doc.metadata,
+    stageScores: doc.stageScores,
+    score:
       doc.stageScores.semantic * SCORE_WEIGHTS.semantic +
       doc.stageScores.keyword * SCORE_WEIGHTS.keyword +
-      doc.stageScores.metadata * SCORE_WEIGHTS.metadata;
+      doc.stageScores.metadata * SCORE_WEIGHTS.metadata,
+  }));
+}
 
-    return {
-      _id: doc._id,
-      content: doc.content,
-      metadata: doc.metadata,
-      score: combinedScore,
-      stageScores: doc.stageScores,
-    };
+function deterministicRerank(items) {
+  return [...items].sort((a, b) => {
+    if ((b.score ?? 0) !== (a.score ?? 0)) {
+      return (b.score ?? 0) - (a.score ?? 0);
+    }
+    return String(a._id).localeCompare(String(b._id));
   });
 }
 
-function rerankResults(items, limit) {
-  return [...items]
-    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-    .slice(0, limit);
-}
+async function fullSearch({ semanticQuery, filters, booleanLogic, limit }) {
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 5;
 
-async function fullSearch({ semanticQuery, keywords, filters, limit }) {
-  const safeLimit = limit ?? 5;
-  debugLog("fullSearch.start", {
+  const metadataQuery = buildMetadataQuery(filters.metadata_filters);
+  const keywordQuery = buildKeywordQuery(filters.keyword_filters);
+  const searchQuery = applyBooleanLogic({
+    metadataQuery,
+    keywordQuery,
+    operator: booleanLogic.operator,
+    negations: [...(booleanLogic.negations || []), ...(filters.exclusions || [])],
+  });
+
+  debugLog("fullSearch.pipeline", {
     safeLimit,
-    semanticQueryLength: semanticQuery?.length ?? 0,
-    keywordCount: keywords?.length ?? 0,
-    filterKeys: filters ? Object.keys(filters) : [],
+    hasMetadataQuery: Boolean(metadataQuery),
+    hasKeywordQuery: Boolean(keywordQuery),
+    operator: booleanLogic.operator,
   });
 
-  const [metadataResults, keywordResults, semanticResults] =
-    await Promise.all([
-      metadataSearch({ filters, limit: safeLimit }),
-      keywordSearch({ keywords, limit: safeLimit }),
-      vectorSearch(semanticQuery, Math.max(safeLimit * 2, 8)),
-    ]);
-  debugLog("fullSearch.parallel.results", {
-    metadataCount: metadataResults.length,
-    keywordCount: keywordResults.length,
-    semanticCount: semanticResults.length,
-  });
+  const [metadataResults, keywordResults, semanticResults] = await Promise.all([
+    mongoSearch(metadataQuery, Math.max(safeLimit * 3, 10)).then((items) =>
+      items.map((item) => ({ ...item, score: 0.7 })),
+    ),
+    mongoSearch(keywordQuery, Math.max(safeLimit * 4, 12)).then((items) =>
+      items.map((item) => ({ ...item, score: 1 })),
+    ),
+    vectorSearch(semanticQuery, Math.max(safeLimit * 2, 8)),
+  ]);
+
+  const booleanFiltered =
+    Object.keys(searchQuery).length === 0
+      ? [...metadataResults, ...keywordResults]
+      : await mongoSearch(searchQuery, Math.max(safeLimit * 5, 15)).then((items) =>
+          items.map((item) => ({ ...item, score: 0.85 })),
+        );
 
   const merged = mergeResults({
-    metadataResults,
+    metadataResults: [...metadataResults, ...booleanFiltered],
     keywordResults,
     semanticResults,
   });
-  const ranked = rerankResults(merged, safeLimit);
-  debugLog("fullSearch.rerank.done", {
-    mergedCount: merged.length,
-    rankedCount: ranked.length,
-  });
+
+  const reranked = deterministicRerank(merged);
+  const selected = reranked.slice(0, safeLimit);
 
   return {
     type: "full_search",
-    items: ranked,
-    missing: ranked.length === 0,
+    items: selected,
+    missing: selected.length === 0,
   };
 }
 

--- a/src/moonmind/retrieval/retrievalEngine.js
+++ b/src/moonmind/retrieval/retrievalEngine.js
@@ -10,14 +10,12 @@ async function fetchGithubStats() {
     debugLog("retrieval.github.missing");
     return { type: "github_stats", items: [], missing: true };
   }
-  debugLog("retrieval.github.success");
   return { type: "github_stats", items: [stats], missing: false };
 }
 
 async function fetchLeetcodeStats(username) {
   debugLog("retrieval.leetcode.start", { username: username ?? null });
   if (!username) {
-    debugLog("retrieval.leetcode.missing_username");
     return { type: "leetcode_stats", items: [], missing: true };
   }
 
@@ -60,12 +58,7 @@ async function fetchLeetcodeStats(username) {
 
   const data = response.data?.data;
   const ranking = rankingResponse.data?.data;
-
   if (!data?.matchedUser || !ranking?.matchedUser) {
-    debugLog("retrieval.leetcode.missing_data", {
-      hasData: Boolean(data?.matchedUser),
-      hasRanking: Boolean(ranking?.matchedUser),
-    });
     return { type: "leetcode_stats", items: [], missing: true };
   }
 
@@ -82,37 +75,27 @@ async function fetchLeetcodeStats(username) {
     ranking: ranking.matchedUser.profile.ranking,
   };
 
-  debugLog("retrieval.leetcode.success");
   return { type: "leetcode_stats", items: [payload], missing: false };
 }
 
-async function retrieve(intentReport) {
-  debugLog("retrieval.dispatch.start", {
-    retrieval: intentReport.execution.retrieval,
-    subtype: intentReport.intentSubtype,
-  });
-
-  if (intentReport.execution.retrieval === "github_stats") {
+async function retrieve(intentReport, directive, metadata = {}) {
+  if (directive.retrieval === "github_stats") {
     return fetchGithubStats();
   }
-  if (intentReport.execution.retrieval === "leetcode_stats") {
-    return fetchLeetcodeStats(intentReport.entities.leetcodeUsername);
+
+  if (directive.retrieval === "leetcode_stats") {
+    return fetchLeetcodeStats(metadata.leetcodeUsername || metadata.username || null);
   }
-  if (intentReport.execution.retrieval === "full_search") {
-    debugLog("retrieval.full_search.start", {
-      queryLength: intentReport.semanticQuery?.length ?? 0,
-      keywordCount: intentReport.keywords?.length ?? 0,
-      limit: intentReport.constraints.limit,
-    });
+
+  if (directive.retrieval === "full_search") {
     return fullSearch({
-      semanticQuery: intentReport.semanticQuery,
-      keywords: intentReport.keywords,
+      semanticQuery: intentReport.filters.keyword_filters.join(" "),
       filters: intentReport.filters,
-      limit: intentReport.constraints.limit,
+      booleanLogic: intentReport.boolean_logic,
+      limit: 8,
     });
   }
 
-  debugLog("retrieval.none");
   return { type: "none", items: [], missing: false };
 }
 


### PR DESCRIPTION
### Motivation
- Formalize the intent classification layer into a deterministic, schema-driven compiler that emits strict JSON and becomes authoritative for routing and execution.
- Enforce single `primary_intent` selection, modifier extraction, scope gating, ambiguity detection, and logical validity checks at classification time.
- Centralize and harden the FULL_SEARCH retrieval pipeline to implement metadata filters, keyword filters, boolean logic, semantic vector search, deterministic reranking and top‑N selection.
- Prevent retrieval or execution when out-of-scope, ambiguous, or logically inconsistent; make execution follow compiler output without reinterpretation.

### Description
- Replaced the legacy intent schema with a new compiler report shape and enums in `src/moonmind/intent/intentReportSchema.js` (primary intent, subtypes, `modifiers`, scope fields, `boolean_logic`, `aggregation`, `logical_validity`).
- Rewrote the intent prompt builder in `src/moonmind/intent/intentExtractor.js` to force strict JSON-only output matching the new required shape and rules (ambiguity, scope, logical checks, allowed/disallowed domains).
- Rebuilt validation and directive derivation in `src/moonmind/intent/intentValidator.js` to enforce exact key sets, subtype compatibility, confidence→clarification coupling, out-of-scope payloads, conflict signaling, and to return an authoritative `getExecutionDirective` for routing.
- Updated the orchestrator in `src/moonmind/index.js` to consume the compiler output as authoritative, to stop early on out-of-scope/ambiguity/conflicts, and to dispatch deterministic plans from `src/moonmind/planning/planBuilder.js` (now accepts directive and encodes explicit retrieval steps).
- Centralized FULL_SEARCH pipeline in `src/moonmind/retrieval/fullSearch.js` to implement metadata query building, keyword query building, boolean logic with negations, semantic vector search, deterministic reranking, and top‑N selection.
- Adapted retrieval dispatch in `src/moonmind/retrieval/retrievalEngine.js` to use the directive model and to wire stats endpoints vs full_search accordingly.
- Adjusted scope gate and grounded response shaping to use new fields (`is_in_scope`, `primary_intent`, `subtype`, `domains`) in `src/moonmind/gate/scopeValidator.js` and `src/moonmind/response/responseComposer.js`.

### Testing
- Static syntax checks: ran `node --check` on the main modified modules (`src/moonmind/index.js`, `src/moonmind/intent/*`, `src/moonmind/retrieval/*`, `src/moonmind/planning/planBuilder.js`, `src/moonmind/gate/scopeValidator.js`, `src/moonmind/response/responseComposer.js`) and they passed.
- Dependency installation attempts: `npm ci` failed due to lockfile mismatch in this environment (registry / lockfile constraints), and `npm install axios@1.6.2` failed with a `403` from the npm registry, preventing full runtime import validation.
- Runtime require check `node -e "require('./src/moonmind/index')"` failed in this environment due to missing/blocked dependency installation (reported `Cannot find module 'axios'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901cdb783483218d417bd9c5036576)