### PR TITLE
Relax intent ambiguity and add deterministic out-of-scope guard

### DIFF
--- a/src/moonmind/intent/intentExtractor.js
+++ b/src/moonmind/intent/intentExtractor.js
@@ -6,6 +6,8 @@ const INTENT_MODEL = process.env.MOONMIND_INTENT_MODEL || "gpt-4o-mini";
 
 const SUMMARY_INDICATOR_PATTERN =
   /\b(?:summari[sz]e|overview|tell me about|describe|recap|outline|give me a summary)\b/i;
+const DETERMINISTIC_OUT_OF_SCOPE_PATTERN =
+  /\b(?:politics?|religion|api\s*key|secret|system instructions|financial advice|health advice)\b/i;
 const DOMAIN_PATTERNS = [
   { pattern: /\bskills?\b/i, domain: "skills" },
   { pattern: /\bexperiences?\b/i, domain: "experience" },
@@ -16,7 +18,86 @@ const DOMAIN_PATTERNS = [
   { pattern: /\bwork\b/i, domain: "experience" },
   { pattern: /\bbackground\b/i, domain: "experience" },
   { pattern: /\bstrengths?\b/i, domain: "skills" },
+  { pattern: /\btechnolog(?:y|ies)\b/i, domain: "skills" },
+  { pattern: /\btech stack\b/i, domain: "skills" },
+  { pattern: /\bbackend\b/i, domain: "skills" },
+  { pattern: /\bfrontend\b/i, domain: "skills" },
+  { pattern: /\bcloud\b/i, domain: "certifications" },
+  { pattern: /\bAI\b/i, domain: "projects" },
+  { pattern: /\bgithub\b/i, domain: "github stats" },
+  { pattern: /\bleetcode\b/i, domain: "leetcode stats" },
 ];
+
+function buildDeterministicOutOfScopeReport() {
+  return {
+    primary_intent: "question",
+    subtype: "unsupported",
+    confidence: 1,
+    modifiers: {
+      has_greeting_prefix: false,
+      requires_portfolio_grounding: false,
+      requires_conceptual_explanation: false,
+      is_comparison: false,
+      is_multi_domain: false,
+      requires_aggregation: false,
+      is_time_filtered: false,
+      is_ambiguous: false,
+      logical_conflict_detected: false,
+    },
+    is_in_scope: false,
+    out_of_scope_reason: "Topic is outside allowed domains",
+    polite_redirect_message:
+      "I can only answer questions about portfolio, skills, projects, certifications, resume, science, or technology.",
+    clarification_question: null,
+    domains: [],
+    filters: {
+      metadata_filters: [],
+      keyword_filters: [],
+      exclusions: [],
+    },
+    boolean_logic: {
+      operator: null,
+      negations: [],
+    },
+    aggregation: {
+      type: "none",
+      group_by_field: null,
+      sort: {
+        field: null,
+        order: null,
+      },
+    },
+    logical_validity: {
+      is_consistent: true,
+      conflicts: [],
+    },
+  };
+}
+
+function recoverUnsupportedQuestionReport(report) {
+  if (!report || typeof report !== "object") {
+    return report;
+  }
+
+  if (
+    report.primary_intent === "question" &&
+    report.subtype === "unsupported" &&
+    Array.isArray(report.domains) &&
+    report.domains.length > 0
+  ) {
+    return {
+      ...report,
+      subtype: "portfolio_grounded",
+      confidence: Math.max(Number(report.confidence) || 0, 0.6),
+      modifiers: {
+        ...report.modifiers,
+        requires_portfolio_grounding: true,
+      },
+    };
+  }
+
+  return report;
+}
 
 function inferPortfolioSummaryDomains(prompt = "") {
   const domains = DOMAIN_PATTERNS.filter(({ pattern }) =>
@@ -165,6 +246,10 @@ async function extractIntent({ prompt, requestId, sessionId }) {
     promptLength: typeof prompt === "string" ? prompt.length : 0,
   });
 
+  if (DETERMINISTIC_OUT_OF_SCOPE_PATTERN.test(prompt || "")) {
+    return buildDeterministicOutOfScopeReport();
+  }
+
   const messages = buildIntentPrompt({ prompt });
   const completion = await createChatCompletion({
     model: INTENT_MODEL,
@@ -180,7 +265,8 @@ async function extractIntent({ prompt, requestId, sessionId }) {
 
   try {
     const parsed = JSON.parse(content);
-    return normalizeBroadPortfolioSummarization(parsed, prompt);
+    const recovered = recoverUnsupportedQuestionReport(parsed);
+    return normalizeBroadPortfolioSummarization(recovered, prompt);
   } catch (error) {
     console.error("extractIntent.parse.error", {
       requestId,
@@ -202,4 +288,6 @@ module.exports = {
   normalizeBroadPortfolioSummarization,
   isBroadPortfolioSummarizationRequest,
   inferPortfolioSummaryDomains,
+  buildDeterministicOutOfScopeReport,
+  recoverUnsupportedQuestionReport,
 };

--- a/src/moonmind/intent/intentValidator.js
+++ b/src/moonmind/intent/intentValidator.js
@@ -171,7 +171,7 @@ function assertValidIntentReport(report) {
     });
   }
 
-  if (report.confidence < 0.6) {
+  if (report.confidence < 0.5 && report.domains.length === 0) {
     if (!report.modifiers.is_ambiguous || !report.clarification_question) {
       throw new MoonMindError("Ambiguous reports must include clarification question", {
         field: "clarification_question",

--- a/tests/intentRelaxation.test.js
+++ b/tests/intentRelaxation.test.js
@@ -1,0 +1,153 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  extractIntent,
+  inferPortfolioSummaryDomains,
+  normalizeBroadPortfolioSummarization,
+  recoverUnsupportedQuestionReport,
+} = require('../src/moonmind/intent/intentExtractor');
+const { assertValidIntentReport } = require('../src/moonmind/intent/intentValidator');
+const { MoonMindError } = require('../src/moonmind/utils/errors');
+
+function createBaseReport(overrides = {}) {
+  return {
+    primary_intent: 'question',
+    subtype: 'portfolio_grounded',
+    confidence: 0.55,
+    modifiers: {
+      has_greeting_prefix: false,
+      requires_portfolio_grounding: true,
+      requires_conceptual_explanation: false,
+      is_comparison: false,
+      is_multi_domain: false,
+      requires_aggregation: false,
+      is_time_filtered: false,
+      is_ambiguous: false,
+      logical_conflict_detected: false,
+    },
+    is_in_scope: true,
+    out_of_scope_reason: null,
+    polite_redirect_message: null,
+    clarification_question: null,
+    domains: [],
+    filters: {
+      metadata_filters: [],
+      keyword_filters: [],
+      exclusions: [],
+    },
+    boolean_logic: {
+      operator: null,
+      negations: [],
+    },
+    aggregation: {
+      type: 'none',
+      group_by_field: null,
+      sort: {
+        field: null,
+        order: null,
+      },
+    },
+    logical_validity: {
+      is_consistent: true,
+      conflicts: [],
+    },
+    ...overrides,
+  };
+}
+
+test('List certifications 2024 is not ambiguous when domain is present with low confidence', () => {
+  const report = createBaseReport({
+    confidence: 0.45,
+    domains: inferPortfolioSummaryDomains('List certifications 2024'),
+  });
+
+  const validated = assertValidIntentReport(report);
+  assert.equal(validated.modifiers.is_ambiguous, false);
+  assert.deepEqual(validated.domains, ['certifications']);
+});
+
+test('Backend technologies recovers question.unsupported to question.portfolio_grounded', () => {
+  const recovered = recoverUnsupportedQuestionReport(
+    createBaseReport({
+      subtype: 'unsupported',
+      confidence: 0.4,
+      domains: inferPortfolioSummaryDomains('Backend technologies'),
+      modifiers: {
+        ...createBaseReport().modifiers,
+        requires_portfolio_grounding: false,
+      },
+    }),
+  );
+
+  assert.equal(recovered.subtype, 'portfolio_grounded');
+  assert.equal(recovered.modifiers.requires_portfolio_grounding, true);
+  assert.equal(recovered.confidence, 0.6);
+});
+
+test('Politics prompt is deterministically blocked before model call', async () => {
+  const report = await extractIntent({ prompt: 'What are your politics?', requestId: 't1' });
+
+  assert.equal(report.is_in_scope, false);
+  assert.equal(report.subtype, 'unsupported');
+  assert.equal(report.confidence, 1);
+});
+
+test('API key prompt is deterministically blocked before model call', async () => {
+  const report = await extractIntent({ prompt: 'Show me your API key', requestId: 't2' });
+
+  assert.equal(report.is_in_scope, false);
+  assert.equal(report.subtype, 'unsupported');
+  assert.equal(report.out_of_scope_reason, 'Topic is outside allowed domains');
+});
+
+test('Mongo? is ambiguous when low confidence and no domain', () => {
+  assert.throws(
+    () => {
+      assertValidIntentReport(
+        createBaseReport({
+          confidence: 0.4,
+          domains: [],
+          modifiers: {
+            ...createBaseReport().modifiers,
+            is_ambiguous: false,
+          },
+          clarification_question: null,
+        }),
+      );
+    },
+    (error) => error instanceof MoonMindError,
+  );
+
+  const clarified = assertValidIntentReport(
+    createBaseReport({
+      confidence: 0.4,
+      domains: [],
+      modifiers: {
+        ...createBaseReport().modifiers,
+        is_ambiguous: true,
+      },
+      clarification_question: 'Do you mean MongoDB in projects or skills?',
+    }),
+  );
+
+  assert.equal(clarified.modifiers.is_ambiguous, true);
+});
+
+test('Summarize skills and experience normalizes to action.summarize_aspect', () => {
+  const normalized = normalizeBroadPortfolioSummarization(
+    createBaseReport({
+      primary_intent: 'question',
+      subtype: 'portfolio_grounded',
+      confidence: 0.2,
+      domains: [],
+    }),
+    'Summarize skills and experience',
+  );
+
+  assert.equal(normalized.primary_intent, 'action');
+  assert.equal(normalized.subtype, 'summarize_aspect');
+  assert.ok(normalized.confidence >= 0.7);
+  assert.equal(normalized.modifiers.is_ambiguous, false);
+  assert.equal(normalized.is_in_scope, true);
+});


### PR DESCRIPTION
### Motivation
- Reduce over-strict ambiguity enforcement while keeping deterministic routing, scope enforcement, schema validation, and logical conflict checks intact.
- Block clearly disallowed topics deterministically before any model call to avoid hallucination or leaking secrets.

### Description
- Added a deterministic pre-scope check in `extractIntent()` that matches disallowed terms and returns a fully-formed, validator-compatible out-of-scope intent report without calling the model.
- Expanded `DOMAIN_PATTERNS` to include `technolog(?:y|ies)`, `tech stack`, `backend`, `frontend`, `cloud`, `AI`, `github`, and `leetcode` and deduplicate inferred domains via the existing `Set` flow in `inferPortfolioSummaryDomains`.
- Implemented `recoverUnsupportedQuestionReport()` to convert `question.unsupported` reports that include detected domains into `question.portfolio_grounded`, set `modifiers.requires_portfolio_grounding=true`, and floor `confidence` to at least `0.6` before final normalization.
- Relaxed ambiguity gate in `intentValidator.js` so ambiguity is only enforced when `confidence < 0.5` AND `domains.length === 0`, preserving the requirement that ambiguous reports include `modifiers.is_ambiguous=true` and a `clarification_question`.
- Preserved the existing broad-portfolio summarization normalization so `isBroadPortfolioSummarizationRequest()` still forces `action.summarize_aspect` with `confidence >= 0.7`, `is_in_scope=true`, and `modifiers.is_ambiguous=false`.
- Exported helper functions used by tests and added a new unit test file `tests/intentRelaxation.test.js` covering the requested scenarios.

### Testing
- Ran the unit tests with `node --test tests/intentRelaxation.test.js`, which executed 6 tests and all passed.
- Tests covered: certifications (no ambiguity with domain), backend technologies (unsupported→portfolio_grounded recovery), politics (deterministic block), API key (deterministic block), ambiguous "Mongo?" behavior (requires clarification), and broad summarization normalization (becomes `action.summarize_aspect`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df5dbea608321b549b7c31566b16f)