### PR TITLE
Sanitize documents and tighten final LLM prompt for MoonMind responses

### DIFF
--- a/src/moonmind/documentSanitizer.js
+++ b/src/moonmind/documentSanitizer.js
@@ -1,0 +1,67 @@
+const SAFE_METADATA_FIELDS = [
+  "domain",
+  "subcategory",
+  "organization",
+  "proficiency_level",
+  "verified",
+  "date_start",
+  "date_end",
+  "completion_year",
+  "is_active",
+  "external_link",
+];
+
+function sanitizeMetadata(metadata) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  const safeMetadata = SAFE_METADATA_FIELDS.reduce((accumulator, field) => {
+    const value = metadata[field];
+    if (value === undefined || value === null || value === "") {
+      return accumulator;
+    }
+
+    return {
+      ...accumulator,
+      [field]: value,
+    };
+  }, {});
+
+  return Object.keys(safeMetadata).length > 0 ? safeMetadata : undefined;
+}
+
+function sanitizeSingleDocument(document = {}) {
+  if (!document || typeof document !== "object") {
+    return null;
+  }
+
+  const content = document.summary_for_embedding || document.content_full;
+  const metadata = sanitizeMetadata(document.metadata);
+
+  const sanitized = {
+    title: document.title || "Untitled",
+    content: content || "",
+    tags: Array.isArray(document.tags) ? document.tags.filter(Boolean) : [],
+  };
+
+  if (metadata) {
+    sanitized.metadata = metadata;
+  }
+
+  return sanitized;
+}
+
+function sanitizeDocumentsForLLM(documents) {
+  if (!Array.isArray(documents)) {
+    return [];
+  }
+
+  return documents
+    .map((document) => sanitizeSingleDocument(document))
+    .filter((document) => Boolean(document));
+}
+
+module.exports = {
+  sanitizeDocumentsForLLM,
+};

--- a/src/moonmind/responseGenerator.js
+++ b/src/moonmind/responseGenerator.js
@@ -1,23 +1,41 @@
 const { createChatCompletion } = require("./adapters/openaiClient");
 const { debugLog } = require("./utils/debug");
+const { sanitizeDocumentsForLLM } = require("./documentSanitizer");
 
 const RESPONSE_MODEL = process.env.MOONMIND_RESPONSE_MODEL || "gpt-4o-mini";
 
 function buildMessages({ query, documents, intent }) {
+  const systemPrompt = [
+    "You are a professional AI assistant representing Ayan (also known as Moonman, Moonman369, MightyAyan, Mr. Maiti, Ayan Maiti).",
+    "Your job is to generate clear, polished, human-friendly responses using only the provided documents.",
+    "STRICT RULES:",
+    "- Do NOT mention internal scores like impact_score.",
+    "- Do NOT mention ranking, embeddings, or retrieval process.",
+    "- Do NOT expose metadata field names or internal JSON structure.",
+    "- Do NOT hallucinate or add facts not present in the documents.",
+    "- If no useful documents are provided, clearly state that no relevant information was found.",
+    "FORMAT RULES:",
+    "- Use clean markdown.",
+    "- Use bullet points or numbered lists where appropriate.",
+    "- Keep the response concise but insightful.",
+    "- Highlight key strengths clearly.",
+    "- If listing items, use bold item titles followed by a short explanation.",
+    `Current user intent: ${intent}.`,
+  ].join("\n");
+
+  const payload = {
+    query,
+    documents,
+  };
+
   return [
     {
       role: "system",
-      content: [
-        "You are MoonMind, a portfolio-grounded assistant.",
-        "Use only the provided documents.",
-        "Do not hallucinate or add facts not present in the documents.",
-        "If no useful documents are provided, explicitly say that no supporting MoonMind data was found.",
-        `The user intent is: ${intent}.`,
-      ].join(" "),
+      content: systemPrompt,
     },
     {
       role: "user",
-      content: JSON.stringify({ query, documents }, null, 2),
+      content: JSON.stringify(payload, null, 2),
     },
   ];
 }
@@ -32,9 +50,33 @@ async function generateResponse({ query, documents, intent }) {
     return "I could not find supporting MoonMind data for that request.";
   }
 
+  debugLog("moonmind.response.sanitization.before", {
+    documentCount: documents.length,
+    sampleDocument: documents[0] || null,
+  });
+
+  const sanitizedDocuments = sanitizeDocumentsForLLM(documents);
+
+  debugLog("moonmind.response.sanitization.after", {
+    documentCount: sanitizedDocuments.length,
+    sampleDocument: sanitizedDocuments[0] || null,
+  });
+
+  const messages = buildMessages({
+    query,
+    documents: sanitizedDocuments,
+    intent,
+  });
+
+  debugLog("moonmind.response.prompt", {
+    model: RESPONSE_MODEL,
+    systemPrompt: messages[0]?.content || "",
+    userPayloadPreview: messages[1]?.content || "",
+  });
+
   const completion = await createChatCompletion({
     model: RESPONSE_MODEL,
-    messages: buildMessages({ query, documents, intent }),
+    messages,
     temperature: 0,
   });
 


### PR DESCRIPTION
### Motivation
- Reduce LLM input noise and prevent exposure of internal system fields like `impact_score`, embeddings, and ranking metadata. 
- Improve final response quality and enforce consistent assistant identity and formatting rules for user-facing outputs.

### Description
- Added `src/moonmind/documentSanitizer.js` with `sanitizeDocumentsForLLM(documents)` to keep only `title`, normalized `content`, `tags`, and a curated safe metadata subset. 
- Updated `src/moonmind/responseGenerator.js` to sanitize ranked documents before the model call and to pass a minimized payload `{ query, documents }` to the LLM. 
- Rewrote the final system prompt to inject alias awareness for Ayan (`Ayan`, `Moonman`, `Moonman369`, `MightyAyan`, `Mr. Maiti`, `Ayan Maiti`) and to strictly forbid mentioning internal scores, retrieval details, embeddings, or raw metadata, while enforcing clean markdown formatting and listing rules. 
- Added readable debug logs for pre-sanitization, post-sanitization, and the final prompt payload sent to the LLM to aid debugging and observability.

### Testing
- Ran the automated test suite with `npm test` and all tests passed (10 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c791fc40f883218e0248664baf0223)