### PR TITLE
Add MoonMind fast-path routing for GitHub and LeetCode stats queries

### DIFF
--- a/src/moonmind/pipeline.js
+++ b/src/moonmind/pipeline.js
@@ -5,6 +5,8 @@ const { rankDocuments } = require("./ranker");
 const { generateResponse } = require("./responseGenerator");
 const { MoonMindError } = require("./utils/errors");
 const { debugLog, serializeError } = require("./utils/debug");
+const { detectStatsQuery } = require("./statsRouter");
+const { getGithubStats, getLeetcodeStats } = require("./statsService");
 
 function buildResponseDocuments(documents = []) {
   if (!Array.isArray(documents)) {
@@ -41,6 +43,65 @@ async function runMoonMindPipeline({ query, sessionId, metadata = {} }) {
   });
 
   try {
+    const statsRoute = detectStatsQuery(trimmedQuery);
+
+    if (statsRoute.isGithub || statsRoute.isLeetcode) {
+      const statsType = statsRoute.isGithub ? "github_stats" : "leetcode_stats";
+      debugLog("moonmind.pipeline.stats_route.triggered", {
+        requestId,
+        statsType,
+      });
+
+      try {
+        const statsData = statsRoute.isGithub
+          ? await getGithubStats()
+          : await getLeetcodeStats();
+
+        debugLog("moonmind.pipeline.stats_route.fetch_success", {
+          requestId,
+          statsType,
+        });
+
+        debugLog("moonmind.pipeline.final_response_trigger", {
+          requestId,
+          documentCount: 0,
+          statsType,
+        });
+
+        const summary = await generateResponse({
+          query: trimmedQuery,
+          documents: [],
+          intent: "stats_query",
+          statsPayload: {
+            type: statsType,
+            data: statsData,
+          },
+        });
+
+        return {
+          status: "success",
+          data: {
+            summary,
+            documents: [],
+          },
+        };
+      } catch (statsError) {
+        debugLog("moonmind.pipeline.stats_route.fetch_failure", {
+          requestId,
+          statsType,
+          error: serializeError(statsError),
+        });
+
+        return {
+          status: "success",
+          data: {
+            summary: "Unable to fetch stats at the moment",
+            documents: [],
+          },
+        };
+      }
+    }
+
     const intentPayload = await extractIntent({
       query: trimmedQuery,
       requestId,

--- a/src/moonmind/responseGenerator.js
+++ b/src/moonmind/responseGenerator.js
@@ -4,7 +4,7 @@ const { sanitizeDocumentsForLLM } = require("./documentSanitizer");
 
 const RESPONSE_MODEL = process.env.MOONMIND_RESPONSE_MODEL || "gpt-4o-mini";
 
-function buildMessages({ query, documents, intent }) {
+function buildMessages({ query, documents, intent, statsPayload }) {
   const systemPrompt = [
     "You are a professional AI assistant representing Ayan (also known as Moonman, Moonman369, MightyAyan, Mr. Maiti, Ayan Maiti).",
     "Your job is to generate clear, polished, human-friendly responses using only the provided documents.",
@@ -17,6 +17,7 @@ function buildMessages({ query, documents, intent }) {
     "- When no documents are found, still answer the user's actual query in a helpful concise way and include a clear note that MoonMind has no matching supporting documents right now.",
     "- If the user message is greeting-only, return a friendly greeting and offer portfolio help.",
     `- If the user message is time based use today's date as a reference to calculate duration: ${Date.now()}`,
+    "- If stats_payload is present, use only stats_payload.data as the source of truth and present clean insights without adding missing fields.",
     "FORMAT RULES:",
     "- Use clean markdown.",
     "- Use bullet points or numbered lists where appropriate.",
@@ -29,7 +30,9 @@ function buildMessages({ query, documents, intent }) {
   const payload = {
     query,
     documents,
-    no_documents_found: !Array.isArray(documents) || documents.length === 0,
+    stats_payload: statsPayload || null,
+    no_documents_found:
+      (!Array.isArray(documents) || documents.length === 0) && !statsPayload,
   };
 
   return [
@@ -44,10 +47,11 @@ function buildMessages({ query, documents, intent }) {
   ];
 }
 
-async function generateResponse({ query, documents, intent }) {
+async function generateResponse({ query, documents, intent, statsPayload = null }) {
   debugLog("moonmind.response.start", {
     intent,
     documentCount: Array.isArray(documents) ? documents.length : 0,
+    hasStatsPayload: Boolean(statsPayload),
   });
 
   debugLog("moonmind.response.sanitization.before", {
@@ -66,6 +70,7 @@ async function generateResponse({ query, documents, intent }) {
     query,
     documents: sanitizedDocuments,
     intent,
+    statsPayload,
   });
 
   debugLog("moonmind.response.prompt", {
@@ -88,6 +93,7 @@ async function generateResponse({ query, documents, intent }) {
   debugLog("moonmind.response.complete", {
     intent,
     documentCount: documents.length,
+    hasStatsPayload: Boolean(statsPayload),
   });
 
   return summary;

--- a/src/moonmind/statsRouter.js
+++ b/src/moonmind/statsRouter.js
@@ -1,0 +1,25 @@
+function detectStatsQuery(prompt) {
+  const normalizedPrompt =
+    typeof prompt === "string" ? prompt.toLowerCase().trim() : "";
+
+  if (!normalizedPrompt) {
+    return { isGithub: false, isLeetcode: false };
+  }
+
+  const hasGithubKeyword = normalizedPrompt.includes("github");
+  const hasLeetcodeKeyword = normalizedPrompt.includes("leetcode");
+  const hasStatsIntent =
+    normalizedPrompt.includes("stats") ||
+    normalizedPrompt.includes("profile") ||
+    normalizedPrompt.includes("moonman") ||
+    normalizedPrompt.includes("ayan");
+
+  return {
+    isGithub: hasGithubKeyword && hasStatsIntent,
+    isLeetcode: hasLeetcodeKeyword && hasStatsIntent,
+  };
+}
+
+module.exports = {
+  detectStatsQuery,
+};

--- a/src/moonmind/statsService.js
+++ b/src/moonmind/statsService.js
@@ -1,0 +1,71 @@
+const axios = require("axios");
+const cache = require("memory-cache");
+const { getStats } = require("../../mongo");
+
+const LEETCODE_API_ENDPOINT = "https://leetcode.com/graphql/";
+const LEETCODE_GRAPHQL_QUERY = `query userSessionProgress($username: String!) {
+  allQuestionsCount { difficulty count }
+  matchedUser(username: $username) {
+    submitStats {
+      acSubmissionNum { difficulty count submissions }
+    }
+  }
+}`;
+const LEETCODE_GRAPHQL_QUERY_RANKING = `query userPublicProfile($username: String!) {
+  matchedUser(username: $username) {
+      profile {
+        ranking
+      }
+    }
+  }`;
+const LEETCODE_DEFAULT_USERNAME =
+  process.env.LEETCODE_USERNAME || "moonman369";
+const LEETCODE_CACHE_TTL_MS = 1000 * 60 * 60;
+
+async function getGithubStats() {
+  return getStats();
+}
+
+async function getLeetcodeStats(username = LEETCODE_DEFAULT_USERNAME) {
+  const cacheKey = `leetcode:${username}`;
+  const cachedResponse = cache.get(cacheKey);
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  const [response, rankingResponse] = await Promise.all([
+    axios.post(LEETCODE_API_ENDPOINT, {
+      query: LEETCODE_GRAPHQL_QUERY,
+      variables: { username },
+      operationName: "userSessionProgress",
+    }),
+    axios.post(LEETCODE_API_ENDPOINT, {
+      query: LEETCODE_GRAPHQL_QUERY_RANKING,
+      variables: { username },
+      operationName: "userPublicProfile",
+    }),
+  ]);
+
+  const data = response.data.data;
+  const stats = {
+    status: "success",
+    username,
+    totalSolved: data.matchedUser.submitStats.acSubmissionNum[0].count,
+    totalQuestions: data.allQuestionsCount[0].count,
+    easySolved: data.matchedUser.submitStats.acSubmissionNum[1].count,
+    totalEasy: data.allQuestionsCount[1].count,
+    mediumSolved: data.matchedUser.submitStats.acSubmissionNum[2].count,
+    totalMedium: data.allQuestionsCount[2].count,
+    hardSolved: data.matchedUser.submitStats.acSubmissionNum[3].count,
+    totalHard: data.allQuestionsCount[3].count,
+    ranking: rankingResponse.data.data.matchedUser.profile.ranking,
+  };
+
+  cache.put(cacheKey, stats, LEETCODE_CACHE_TTL_MS);
+  return stats;
+}
+
+module.exports = {
+  getGithubStats,
+  getLeetcodeStats,
+};

--- a/src/routes/github.js
+++ b/src/routes/github.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { getStats } = require("../../mongo");
+const { getGithubStats } = require("../moonmind/statsService");
 
 /**
  * @swagger
@@ -19,7 +19,7 @@ const { getStats } = require("../../mongo");
  */
 router.get("/", async (req, resp) => {
   try {
-    const stats = await getStats();
+    const stats = await getGithubStats();
     resp.status(200).json(stats);
   } catch (e) {
     console.error("github.route.error", {

--- a/src/routes/leetcode.js
+++ b/src/routes/leetcode.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const axios = require("axios");
-const cache = require("memory-cache");
+const { getLeetcodeStats } = require("../moonmind/statsService");
 
 /**
  * @swagger
@@ -26,59 +25,9 @@ const cache = require("memory-cache");
  *         description: Server error
  */
 router.get("/:username", async (req, resp) => {
-  const cachedResponse = cache.get(req.params.username);
-  if (cachedResponse) {
-    return resp.status(200).json(cachedResponse);
-  }
-
   try {
-    const LEETCODE_API_ENDPOINT = "https://leetcode.com/graphql/";
-    const LEETCODE_GRAPHQL_QUERY = `query userSessionProgress($username: String!) {
-      allQuestionsCount { difficulty count }
-      matchedUser(username: $username) {
-        submitStats {
-          acSubmissionNum { difficulty count submissions }
-        }
-      }
-    }`;
-    const LEETCODE_GRAPHQL_QUERY_RANKING = `query userPublicProfile($username: String!) {
-      matchedUser(username: $username) {
-          profile {
-            ranking
-          }
-        }
-      }`;
-
-    const [response, rankingResponse] = await Promise.all([
-      axios.post(LEETCODE_API_ENDPOINT, {
-        query: LEETCODE_GRAPHQL_QUERY,
-        variables: { username: req.params.username },
-        operationName: "userSessionProgress",
-      }),
-      axios.post(LEETCODE_API_ENDPOINT, {
-        query: LEETCODE_GRAPHQL_QUERY_RANKING,
-        variables: { username: req.params.username },
-        operationName: "userPublicProfile",
-      }),
-    ]);
-
-    const data = response.data.data;
-    const obj = {
-      status: "success",
-      totalSolved: data.matchedUser.submitStats.acSubmissionNum[0].count,
-      totalQuestions: data.allQuestionsCount[0].count,
-      easySolved: data.matchedUser.submitStats.acSubmissionNum[1].count,
-      totalEasy: data.allQuestionsCount[1].count,
-      mediumSolved: data.matchedUser.submitStats.acSubmissionNum[2].count,
-      totalMedium: data.allQuestionsCount[2].count,
-      hardSolved: data.matchedUser.submitStats.acSubmissionNum[3].count,
-      totalHard: data.allQuestionsCount[3].count,
-      ranking: rankingResponse.data.data.matchedUser.profile.ranking,
-    };
-
-    cache.put(req.params.username, obj, 1000 * 60 * 60); // Cache for 1 hour
-
-    resp.status(200).json(obj);
+    const stats = await getLeetcodeStats(req.params.username);
+    resp.status(200).json(stats);
   } catch (e) {
     console.error("leetcode.route.error", {
       username: req.params?.username,


### PR DESCRIPTION
### Motivation

- Add a parallel, keyword-driven routing path for GitHub/LeetCode stats/profile queries so these requests can fetch live stats and skip the document retrieval pipeline. 
- Reuse existing live-data logic for GitHub and LeetCode to avoid duplication and keep the retrieval/ranking flow untouched for non-stats queries.
- Ensure responses are generated by the final LLM step using a structured stats payload and include clear logging and graceful failure handling.

### Description

- Added a keyword-based detector `detectStatsQuery(prompt)` in `src/moonmind/statsRouter.js` to identify GitHub/LeetCode stats/profile prompts (case-insensitive).
- Implemented `src/moonmind/statsService.js` exposing `getGithubStats()` and `getLeetcodeStats()` that reuse existing GitHub/LeetCode fetch logic and include caching for LeetCode.
- Updated the main pipeline in `src/moonmind/pipeline.js` to run `detectStatsQuery` before intent extraction and, when matched, to fetch stats, bypass retrieval/ranking, call `generateResponse` with a structured `statsPayload: { type, data }`, and return a stats-only response; a graceful fallback message is returned on fetch failure.
- Extended `src/moonmind/responseGenerator.js` to accept an optional `statsPayload` and to include guidance in the system prompt to treat `statsPayload.data` as the source of truth for stats-only responses.
- Reworked API routes `src/routes/github.js` and `src/routes/leetcode.js` to reuse the new `statsService` fetchers instead of duplicating logic.
- Added debug logging for stats route trigger, fetch success, and fetch failure events; non-stats pipeline logic remains unchanged.

### Testing

- Attempted `npm test -- --runInBand tests/moonmindPipeline.test.js tests/pipelineResponseShape.test.js tests/responseGeneratorPrompt.test.js` which failed due to the Node test runner not recognizing `--runInBand`.
- Ran `npm test -- tests/moonmindPipeline.test.js tests/pipelineResponseShape.test.js tests/responseGeneratorPrompt.test.js` and all specified tests passed successfully.
- The test run covered `tests/moonmindPipeline.test.js`, `tests/pipelineResponseShape.test.js`, and `tests/responseGeneratorPrompt.test.js` with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf91450fe08321aaccd53fd158a486)