### PR TITLE
Fix retrieval collection mismatch — align read path with write path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,7 @@ MOONMIND_VECTOR_FIELD=embedding
 MOONMIND_SUMMARY_MIN_SENTENCES=3
 MOONMIND_SUMMARY_MAX_SENTENCES=6
 MOONMIND_ENFORCE_SUMMARY_SENTENCE_RANGE=true
-# Defaults to ON unless set to the literal string "false" — keep it off in prod.
-MOONMIND_DEBUG=false
+# Verbose MoonMind logging (intent -> retrieval steps -> ranking -> response).
+# Emits the retrieval-mechanism step logs to stdout / `docker compose logs`.
+# Enabled unless set to the literal string "false"; set to "false" to silence.
+MOONMIND_DEBUG=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     container_name: portfolio-stats-api
     env_file:
       - ./.env
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
     ports:
       # Bind to loopback only: Nginx reverse-proxies to localhost on this port,
       # so the app is never exposed publicly and no VM firewall rule is needed.

--- a/src/moonmind/ranker.js
+++ b/src/moonmind/ranker.js
@@ -1,3 +1,5 @@
+const { debugLog } = require("./utils/debug");
+
 function clampScore(value) {
   if (!Number.isFinite(value)) {
     return 0;
@@ -15,7 +17,7 @@ function clampScore(value) {
 }
 
 function rankDocuments(documents = [], limit = 5) {
-  return [...documents]
+  const ranked = [...documents]
     .map((document) => {
       const semanticScore = clampScore(document.semantic_score ?? 0);
       const keywordScore = clampScore(document.keyword_match ?? 0);
@@ -40,6 +42,20 @@ function rankDocuments(documents = [], limit = 5) {
       return String(left.id).localeCompare(String(right.id));
     })
     .slice(0, limit);
+
+  debugLog("moonmind.ranker.scored", {
+    inputCount: documents.length,
+    returnedCount: ranked.length,
+    ranked: ranked.map((document) => ({
+      id: document.id,
+      score: document.score,
+      semantic: clampScore(document.semantic_score ?? 0),
+      keyword: clampScore(document.keyword_match ?? 0),
+      metadata: clampScore(document.metadata_match ?? 0),
+    })),
+  });
+
+  return ranked;
 }
 
 module.exports = {

--- a/src/moonmind/retrieval/vectorSearch.js
+++ b/src/moonmind/retrieval/vectorSearch.js
@@ -1,13 +1,15 @@
 const { connectToDatabase } = require("../../../mongo");
 const { createEmbedding } = require("../adapters/openaiClient");
 const { debugLog, serializeError } = require("../utils/debug");
+const VECTOR_CONFIG = require("../../../config/vectorConfig");
 
-const EMBEDDING_MODEL =
-  process.env.MOONMIND_EMBEDDING_MODEL || "text-embedding-3-small";
-const VECTOR_COLLECTION =
-  process.env.MOONMIND_VECTOR_COLLECTION || "moonmind_documents";
+// Resolve from the shared VECTOR_CONFIG so the read path stays aligned with the
+// write path (same collection, index and embedding model). MOONMIND_VECTOR_INDEX
+// is still honored as a fallback for the older env-var name.
+const EMBEDDING_MODEL = VECTOR_CONFIG.EMBEDDING_MODEL;
+const VECTOR_COLLECTION = VECTOR_CONFIG.DOCUMENT_COLLECTION;
 const VECTOR_INDEX =
-  process.env.MOONMIND_VECTOR_INDEX || "moonmind_vector_index";
+  process.env.MOONMIND_VECTOR_INDEX || VECTOR_CONFIG.VECTOR_INDEX_NAME;
 const VECTOR_FIELD = process.env.MOONMIND_VECTOR_FIELD || "embedding";
 
 async function embedQuery(query) {

--- a/src/moonmind/retrievalEngine.js
+++ b/src/moonmind/retrievalEngine.js
@@ -3,8 +3,9 @@ const { vectorSearch } = require("./retrieval/vectorSearch");
 const { debugLog } = require("./utils/debug");
 const VECTOR_CONFIG = require("../../config/vectorConfig");
 
-const VECTOR_COLLECTION =
-  process.env.MOONMIND_VECTOR_COLLECTION || "moonmind_documents";
+// Use the same collection the write path (vectorMemoryService) persists to,
+// so read and write can never diverge on the default.
+const VECTOR_COLLECTION = VECTOR_CONFIG.DOCUMENT_COLLECTION;
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -182,6 +183,7 @@ function buildKeywordQuery(query, intentPayload) {
 
 async function runMongoQuery(query, limit) {
   if (!query || Object.keys(query).length === 0) {
+    debugLog("moonmind.retrieval.mongo.skipped", { reason: "empty_query" });
     return [];
   }
 
@@ -268,10 +270,13 @@ async function retrieveDocuments({
 
   if (retrievalPlan.semantic) {
     tasks.push(
-      vectorSearch(query, Math.max(limit, 10)).then((documents) => ({
-        source: "semantic",
-        documents,
-      })),
+      vectorSearch(query, Math.max(limit, 10)).then((documents) => {
+        debugLog("moonmind.retrieval.strategy.result", {
+          source: "semantic",
+          count: documents.length,
+        });
+        return { source: "semantic", documents };
+      }),
     );
   }
 
@@ -280,10 +285,13 @@ async function retrieveDocuments({
       runMongoQuery(
         buildKeywordQuery(query, intentPayload),
         Math.max(limit, 10),
-      ).then((documents) => ({
-        source: "keyword",
-        documents,
-      })),
+      ).then((documents) => {
+        debugLog("moonmind.retrieval.strategy.result", {
+          source: "keyword",
+          count: documents.length,
+        });
+        return { source: "keyword", documents };
+      }),
     );
   }
 
@@ -292,10 +300,13 @@ async function retrieveDocuments({
       runMongoQuery(
         buildMetadataQuery(intentPayload, metadata),
         Math.max(limit, 10),
-      ).then((documents) => ({
-        source: "metadata",
-        documents,
-      })),
+      ).then((documents) => {
+        debugLog("moonmind.retrieval.strategy.result", {
+          source: "metadata",
+          count: documents.length,
+        });
+        return { source: "metadata", documents };
+      }),
     );
   }
 
@@ -305,6 +316,10 @@ async function retrieveDocuments({
   debugLog("moonmind.retrieval.complete", {
     query,
     selectedStrategies,
+    perStrategyCounts: settled.map(({ source, documents: docs }) => ({
+      source,
+      count: docs.length,
+    })),
     resultsCount: documents.length,
   });
 


### PR DESCRIPTION
config

The retrieval read path (vectorSearch, retrievalEngine) had different default
collection names than the write path (vectorMemoryService), causing queries to
hit an empty collection when MOONMIND_VECTOR_COLLECTION was unset.

- Route retrievalEngine and vectorSearch through shared VECTOR_CONFIG
- Unify embedding model and vector index resolution
- Read and write paths now always use the same collection by default
- Resolves silent zero-result queries when env var is missing