### PR TITLE
Improve retrieval reliability: RRF fusion, semantic thresholds, and content-based embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,25 @@ MOONMIND_VECTOR_FIELD=embedding
 MOONMIND_SUMMARY_MIN_SENTENCES=3
 MOONMIND_SUMMARY_MAX_SENTENCES=6
 MOONMIND_ENFORCE_SUMMARY_SENTENCE_RANGE=true
+
+# ---- Retrieval tuning (all optional; safe defaults shown) ----
+# ANN candidates scanned before the vector limit. Higher = better recall.
+MOONMIND_VECTOR_NUM_CANDIDATES=150
+# Reciprocal Rank Fusion constant (standard default 60).
+MOONMIND_RRF_K=60
+# Minimum Atlas cosine score ((1+cos)/2, 0..1) a doc must reach to survive
+# ranking. 0 = disabled. Calibrate with scripts/eval/retrievalEval.js, then set
+# to the knee (text-embedding-3-small real matches usually land ~0.6-0.8).
+MOONMIND_MIN_SEMANTIC_SCORE=0
+# Second-stage LLM reranker over the top fused candidates (adds one LLM call).
+MOONMIND_RERANK_ENABLED=false
+MOONMIND_RERANK_CANDIDATES=20
+# MOONMIND_RERANK_MODEL=gpt-4o-mini
+# Query decomposition / multi-query fan-out for multi-part prompts (adds LLM
+# calls: one to split + intent+retrieval per sub-query).
+MOONMIND_DECOMPOSE_ENABLED=false
+MOONMIND_DECOMPOSE_MAX_SUBQUERIES=3
+# MOONMIND_DECOMPOSE_MODEL=gpt-4o-mini
 # Verbose MoonMind logging (intent -> retrieval steps -> ranking -> response).
 # Emits the retrieval-mechanism step logs to stdout / `docker compose logs`.
 # Enabled unless set to the literal string "false"; set to "false" to silence.

--- a/config/vectorConfig.js
+++ b/config/vectorConfig.js
@@ -25,6 +25,24 @@ function parseBooleanFlag(value, fallback = true) {
   return fallback;
 }
 
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function parseUnitFloat(value, fallback) {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
 const SUMMARY_MIN_SENTENCES = parseSentenceBound(
   process.env.MOONMIND_SUMMARY_MIN_SENTENCES,
   3,
@@ -52,6 +70,36 @@ const VECTOR_CONFIG = Object.freeze({
   SUMMARY_MIN_SENTENCES,
   SUMMARY_MAX_SENTENCES,
   ENFORCE_SUMMARY_SENTENCE_RANGE,
+  // --- Retrieval tuning ---------------------------------------------------
+  // How many ANN candidates the $vectorSearch stage scans before applying the
+  // limit. Higher = better recall, slightly more latency. Only affects recall,
+  // never correctness, so it is safe to raise.
+  VECTOR_NUM_CANDIDATES: parsePositiveInt(
+    process.env.MOONMIND_VECTOR_NUM_CANDIDATES,
+    150,
+  ),
+  // Reciprocal Rank Fusion constant. Standard default is 60; larger values
+  // flatten the contribution of top ranks across arms.
+  RRF_K: parsePositiveInt(process.env.MOONMIND_RRF_K, 60),
+  // Minimum raw Atlas cosine vectorSearchScore ((1+cos)/2, in [0,1]) a document
+  // must reach to survive ranking. 0 disables the gate (default, no behaviour
+  // change) so it can be calibrated against the eval harness before enabling.
+  MIN_SEMANTIC_SCORE: parseUnitFloat(process.env.MOONMIND_MIN_SEMANTIC_SCORE, 0),
+  // Feature flags for the heavier read-path stages. Default off so latency/cost
+  // stay unchanged until deliberately enabled.
+  RERANK_ENABLED: parseBooleanFlag(process.env.MOONMIND_RERANK_ENABLED, false),
+  RERANK_CANDIDATES: parsePositiveInt(
+    process.env.MOONMIND_RERANK_CANDIDATES,
+    20,
+  ),
+  DECOMPOSE_ENABLED: parseBooleanFlag(
+    process.env.MOONMIND_DECOMPOSE_ENABLED,
+    false,
+  ),
+  DECOMPOSE_MAX_SUBQUERIES: parsePositiveInt(
+    process.env.MOONMIND_DECOMPOSE_MAX_SUBQUERIES,
+    3,
+  ),
   ALLOWED_CATEGORIES: [
     "skill",
     "certification",

--- a/scripts/eval/goldset.json
+++ b/scripts/eval/goldset.json
@@ -1,0 +1,29 @@
+[
+  {
+    "_comment": "TEMPLATE — replace expected_ids with real document ids from your moonmindVectorMemory collection. Cover the four categories below: single-domain, multi-part, content_full-only answers, and should-return-nothing.",
+
+    "query": "What backend technologies does Ayan work with?",
+    "expected_ids": ["REPLACE_WITH_REAL_SKILL_DOC_ID"]
+  },
+  {
+    "query": "Tell me about Ayan's projects",
+    "expected_ids": ["REPLACE_WITH_REAL_PROJECT_DOC_ID"]
+  },
+  {
+    "query": "What certifications does Ayan hold?",
+    "expected_ids": ["REPLACE_WITH_REAL_CERT_DOC_ID"]
+  },
+  {
+    "query": "my github stats and my projects",
+    "expected_ids": ["REPLACE_WITH_REAL_PROJECT_DOC_ID"]
+  },
+  {
+    "query": "Which project involved low-latency or high-performance work?",
+    "expected_ids": ["REPLACE_WITH_DOC_WHOSE_DETAIL_LIVES_IN_content_full"]
+  },
+  {
+    "query": "What is Ayan's favourite pizza topping?",
+    "expected_ids": [],
+    "expect_empty": true
+  }
+]

--- a/scripts/eval/retrievalEval.js
+++ b/scripts/eval/retrievalEval.js
@@ -1,0 +1,121 @@
+"use strict";
+
+/**
+ * Retrieval quality harness. Runs a labelled gold set through the real
+ * retrieval path (intent -> retrieve -> RRF fuse -> rank) and reports
+ * Recall@5, Recall@10, MRR and no-hit precision.
+ *
+ * Requires live MONGODB + OPENAI credentials in the environment (same as the
+ * app). Capture a baseline BEFORE changing config, then re-run after each
+ * change / env-flag flip to attribute the delta.
+ *
+ * Usage:
+ *   node scripts/eval/retrievalEval.js
+ *   node scripts/eval/retrievalEval.js path/to/custom-goldset.json
+ */
+
+const path = require("path");
+
+// Load .env from the project root regardless of the current working directory.
+require("dotenv").config({ path: path.join(__dirname, "..", "..", ".env") });
+const { extractIntent } = require("../../src/moonmind/intentExtractor");
+const { retrieveDocuments } = require("../../src/moonmind/retrievalEngine");
+const { rankDocuments } = require("../../src/moonmind/ranker");
+
+const GOLDSET_PATH = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(__dirname, "goldset.json");
+
+const TOP_K = 10;
+
+async function retrieveTopK(query) {
+  const intentPayload = await extractIntent({ query, requestId: "eval" });
+  const { documents } = await retrieveDocuments({
+    query,
+    intentPayload,
+    metadata: {},
+    limit: 10,
+  });
+  const ranked = rankDocuments(documents, TOP_K);
+  return ranked.map((doc) => String(doc.id));
+}
+
+function recallAtK(retrieved, expected, k) {
+  if (expected.length === 0) {
+    return null;
+  }
+  const topK = new Set(retrieved.slice(0, k));
+  const hits = expected.filter((id) => topK.has(String(id))).length;
+  return hits / expected.length;
+}
+
+function reciprocalRank(retrieved, expected) {
+  const expectedSet = new Set(expected.map(String));
+  for (let i = 0; i < retrieved.length; i += 1) {
+    if (expectedSet.has(retrieved[i])) {
+      return 1 / (i + 1);
+    }
+  }
+  return 0;
+}
+
+async function main() {
+  const goldset = require(GOLDSET_PATH);
+  if (!Array.isArray(goldset) || goldset.length === 0) {
+    throw new Error(`Gold set at ${GOLDSET_PATH} is empty or not an array`);
+  }
+
+  const rows = [];
+  const recall5 = [];
+  const recall10 = [];
+  const mrr = [];
+  let emptyCases = 0;
+  let emptyCorrect = 0;
+
+  for (const entry of goldset) {
+    const expected = Array.isArray(entry.expected_ids) ? entry.expected_ids : [];
+    // eslint-disable-next-line no-await-in-loop
+    const retrieved = await retrieveTopK(entry.query);
+
+    if (entry.expect_empty) {
+      emptyCases += 1;
+      const correct = retrieved.length === 0;
+      if (correct) emptyCorrect += 1;
+      rows.push({ query: entry.query, expect_empty: true, returned: retrieved.length, ok: correct });
+      continue;
+    }
+
+    const r5 = recallAtK(retrieved, expected, 5);
+    const r10 = recallAtK(retrieved, expected, 10);
+    const rr = reciprocalRank(retrieved, expected);
+    if (r5 != null) recall5.push(r5);
+    if (r10 != null) recall10.push(r10);
+    mrr.push(rr);
+
+    rows.push({
+      query: entry.query,
+      recall5: r5 != null ? r5.toFixed(2) : "-",
+      recall10: r10 != null ? r10.toFixed(2) : "-",
+      rr: rr.toFixed(2),
+    });
+  }
+
+  const avg = (arr) => (arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0);
+
+  console.table(rows);
+  console.log("\n=== Aggregate ===");
+  console.log(`Recall@5:  ${avg(recall5).toFixed(3)}`);
+  console.log(`Recall@10: ${avg(recall10).toFixed(3)}`);
+  console.log(`MRR:       ${avg(mrr).toFixed(3)}`);
+  if (emptyCases > 0) {
+    console.log(
+      `No-hit precision: ${(emptyCorrect / emptyCases).toFixed(3)} (${emptyCorrect}/${emptyCases})`,
+    );
+  }
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error("retrievalEval.fatal", error);
+  process.exit(1);
+});

--- a/scripts/reembed.js
+++ b/scripts/reembed.js
@@ -1,0 +1,88 @@
+"use strict";
+
+/**
+ * One-time backfill: recompute the `embedding` of every document in the vector
+ * collection using the improved embedding input (title + tags + content_full,
+ * falling back to the summary). Run this AFTER deploying the embeddingGenerator
+ * change so stored vectors match the new query-side representation.
+ *
+ * Usage:
+ *   node scripts/reembed.js --dry-run     # report only, no writes
+ *   node scripts/reembed.js               # re-embed and update in place
+ *
+ * Safe to re-run (idempotent-ish): it only rewrites `embedding` + `updated_at`.
+ * Recommended: run against a staging copy first and compare eval metrics
+ * (scripts/eval/retrievalEval.js) before promoting to production.
+ */
+
+// Load .env from the project root regardless of the current working directory,
+// so the script works when invoked as `node scripts/reembed.js` from anywhere.
+require("dotenv").config({ path: require("path").join(__dirname, "..", ".env") });
+
+const { connectToDatabase } = require("../mongo");
+const VECTOR_CONFIG = require("../config/vectorConfig");
+const {
+  buildEmbeddingInput,
+  generateEmbeddingVector,
+} = require("../utils/embeddingGenerator");
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+async function main() {
+  const { db } = await connectToDatabase({ apiStrict: false });
+  const collection = db.collection(VECTOR_CONFIG.DOCUMENT_COLLECTION);
+
+  const cursor = collection.find(
+    {},
+    {
+      projection: {
+        _id: 0,
+        id: 1,
+        title: 1,
+        tags: 1,
+        content_full: 1,
+        summary_for_embedding: 1,
+      },
+    },
+  );
+
+  let processed = 0;
+  let updated = 0;
+  let failed = 0;
+
+  // eslint-disable-next-line no-await-in-loop
+  for (let doc = await cursor.next(); doc; doc = await cursor.next()) {
+    processed += 1;
+    const input = buildEmbeddingInput(doc);
+
+    if (DRY_RUN) {
+      console.log(`[dry-run] ${doc.id} :: ${input.slice(0, 120).replace(/\n/g, " ")}`);
+      continue;
+    }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const embedding = await generateEmbeddingVector(input);
+      // eslint-disable-next-line no-await-in-loop
+      await collection.updateOne(
+        { id: doc.id },
+        { $set: { embedding, updated_at: new Date().toISOString() } },
+      );
+      updated += 1;
+      console.log(`[ok] ${doc.id} (${embedding.length} dims)`);
+    } catch (error) {
+      failed += 1;
+      console.error(`[fail] ${doc.id}: ${error?.message}`);
+    }
+  }
+
+  console.log(
+    `\nDone. processed=${processed} updated=${updated} failed=${failed} dryRun=${DRY_RUN}`,
+  );
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error("reembed.fatal", error);
+  process.exit(1);
+});

--- a/services/vectorMemoryService.js
+++ b/services/vectorMemoryService.js
@@ -10,6 +10,7 @@ const {
 } = require("../validators/memoryValidator");
 const {
   generateDeterministicSummary,
+  buildEmbeddingInput,
   generateEmbeddingVector,
 } = require("../utils/embeddingGenerator");
 
@@ -127,7 +128,9 @@ async function createDocument(payload) {
     summary_for_embedding: summary,
   };
 
-  const embedding = await generateEmbeddingVector(documentToPersist.summary_for_embedding);
+  const embedding = await generateEmbeddingVector(
+    buildEmbeddingInput(documentToPersist),
+  );
 
   const { client, db } = await connectToDatabase({ apiStrict: false });
   const session = client.startSession();
@@ -178,11 +181,13 @@ async function updateDocument(payload) {
     summary_for_embedding: summary,
   };
 
-  const summaryChanged =
-    existing.summary_for_embedding !== normalizedUpdate.summary_for_embedding;
+  // Re-embed whenever any input to the embedding text changes (title, tags,
+  // content_full or summary), not just the summary field.
+  const embeddingInputChanged =
+    buildEmbeddingInput(existing) !== buildEmbeddingInput(normalizedUpdate);
 
-  const embedding = summaryChanged
-    ? await generateEmbeddingVector(normalizedUpdate.summary_for_embedding)
+  const embedding = embeddingInputChanged
+    ? await generateEmbeddingVector(buildEmbeddingInput(normalizedUpdate))
     : existing.embedding;
 
   const updatedDoc = {

--- a/src/moonmind/pipeline.js
+++ b/src/moonmind/pipeline.js
@@ -2,11 +2,16 @@ const crypto = require("crypto");
 const { extractIntent } = require("./intentExtractor");
 const { retrieveDocuments } = require("./retrievalEngine");
 const { rankDocuments } = require("./ranker");
+const { rerankDocuments } = require("./ranking/llmReranker");
+const { decomposeQuery } = require("./planning/queryDecomposer");
 const { generateResponse } = require("./responseGenerator");
 const { MoonMindError } = require("./utils/errors");
 const { debugLog, serializeError } = require("./utils/debug");
 const { detectStatsQuery } = require("./statsRouter");
 const { getGithubStats, getLeetcodeStats } = require("./statsService");
+const VECTOR_CONFIG = require("../../config/vectorConfig");
+
+const FINAL_DOCUMENT_LIMIT = 5;
 
 function buildResponseDocuments(documents = []) {
   if (!Array.isArray(documents)) {
@@ -27,6 +32,112 @@ function buildResponseDocuments(documents = []) {
   });
 }
 
+// Union the fused results of several sub-queries, deduping by id. A document
+// relevant to multiple sub-questions accumulates RRF score (desirable), and we
+// keep the highest semantic score and the richest (content-bearing) copy.
+function unionDocuments(groups) {
+  const merged = new Map();
+
+  groups.forEach((documents) => {
+    (documents || []).forEach((document) => {
+      if (document == null || document.id == null) {
+        return;
+      }
+
+      const id = String(document.id);
+      const existing = merged.get(id);
+
+      if (!existing) {
+        merged.set(id, { ...document });
+        return;
+      }
+
+      const nextRrf = (existing.rrf_score || 0) + (document.rrf_score || 0);
+      const nextSemantic = Math.max(
+        existing.semantic_score || 0,
+        document.semantic_score || 0,
+      );
+      const base =
+        !existing.content_full && document.content_full ? document : existing;
+
+      merged.set(id, {
+        ...base,
+        rrf_score: nextRrf,
+        semantic_score: nextSemantic,
+      });
+    });
+  });
+
+  return Array.from(merged.values());
+}
+
+// Full retrieval sub-flow: optional decomposition -> per-(sub)query intent +
+// retrieval -> union -> rank (with semantic gate) -> optional LLM rerank.
+async function retrieveAndRank({ query, sessionId, metadata, requestId }) {
+  const subqueries = VECTOR_CONFIG.DECOMPOSE_ENABLED
+    ? await decomposeQuery({ query, requestId })
+    : [query];
+
+  const perSubquery = await Promise.all(
+    subqueries.map(async (subquery) => {
+      const intentPayload = await extractIntent({
+        query: subquery,
+        requestId,
+        sessionId,
+      });
+
+      debugLog("moonmind.pipeline.plan", {
+        requestId,
+        subquery,
+        retrieval_plan: intentPayload.retrieval_plan,
+        entities: intentPayload.entities,
+      });
+
+      const result = await retrieveDocuments({
+        query: subquery,
+        intentPayload,
+        metadata,
+        limit: 10,
+      });
+
+      return { intent: intentPayload.intent, documents: result.documents };
+    }),
+  );
+
+  const primaryIntent = perSubquery[0]?.intent || "question";
+  const unioned =
+    subqueries.length > 1
+      ? unionDocuments(perSubquery.map((entry) => entry.documents))
+      : perSubquery[0]?.documents || [];
+
+  // When reranking, keep a wider candidate pool for the reranker to reorder.
+  const candidateLimit = VECTOR_CONFIG.RERANK_ENABLED
+    ? Math.max(VECTOR_CONFIG.RERANK_CANDIDATES, FINAL_DOCUMENT_LIMIT)
+    : FINAL_DOCUMENT_LIMIT;
+
+  const ranked = rankDocuments(unioned, candidateLimit);
+
+  const finalDocuments = VECTOR_CONFIG.RERANK_ENABLED
+    ? await rerankDocuments({
+        query,
+        documents: ranked,
+        limit: FINAL_DOCUMENT_LIMIT,
+      })
+    : ranked.slice(0, FINAL_DOCUMENT_LIMIT);
+
+  debugLog("moonmind.pipeline.ranking", {
+    requestId,
+    subqueryCount: subqueries.length,
+    reranked: VECTOR_CONFIG.RERANK_ENABLED,
+    rankedDocuments: finalDocuments.map((document) => ({
+      id: document.id,
+      score: document.score,
+    })),
+  });
+
+  return { documents: finalDocuments, intent: primaryIntent };
+}
+
 async function runMoonMindPipeline({ query, sessionId, metadata = {} }) {
   const requestId = crypto.randomUUID();
 
@@ -44,24 +155,48 @@ async function runMoonMindPipeline({ query, sessionId, metadata = {} }) {
 
   try {
     const statsRoute = detectStatsQuery(trimmedQuery);
+    let statsPayload = null;
 
     if (statsRoute.isGithub || statsRoute.isLeetcode) {
       const statsType = statsRoute.isGithub ? "github_stats" : "leetcode_stats";
       debugLog("moonmind.pipeline.stats_route.triggered", {
         requestId,
         statsType,
+        isPureStats: statsRoute.isPureStats,
       });
 
       try {
         const statsData = statsRoute.isGithub
           ? await getGithubStats()
           : await getLeetcodeStats();
-
+        statsPayload = { type: statsType, data: statsData };
         debugLog("moonmind.pipeline.stats_route.fetch_success", {
           requestId,
           statsType,
         });
+      } catch (statsError) {
+        debugLog("moonmind.pipeline.stats_route.fetch_failure", {
+          requestId,
+          statsType,
+          error: serializeError(statsError),
+        });
 
+        // Pure stats query with no docs to fall back on: keep prior behaviour.
+        if (statsRoute.isPureStats) {
+          return {
+            status: "success",
+            data: {
+              summary: "Unable to fetch stats at the moment",
+              documents: [],
+            },
+          };
+        }
+        // Mixed query: degrade gracefully to a docs-only answer.
+        statsPayload = null;
+      }
+
+      // Pure stats query: bypass retrieval entirely, as before.
+      if (statsRoute.isPureStats) {
         debugLog("moonmind.pipeline.final_response_trigger", {
           requestId,
           documentCount: 0,
@@ -72,74 +207,35 @@ async function runMoonMindPipeline({ query, sessionId, metadata = {} }) {
           query: trimmedQuery,
           documents: [],
           intent: "stats_query",
-          statsPayload: {
-            type: statsType,
-            data: statsData,
-          },
+          statsPayload,
         });
 
         return {
           status: "success",
-          data: {
-            summary,
-            documents: [],
-          },
-        };
-      } catch (statsError) {
-        debugLog("moonmind.pipeline.stats_route.fetch_failure", {
-          requestId,
-          statsType,
-          error: serializeError(statsError),
-        });
-
-        return {
-          status: "success",
-          data: {
-            summary: "Unable to fetch stats at the moment",
-            documents: [],
-          },
+          data: { summary, documents: [] },
         };
       }
+      // Mixed stats + portfolio query: fall through and retrieve documents too.
     }
 
-    const intentPayload = await extractIntent({
+    const { documents: rankedDocuments, intent } = await retrieveAndRank({
       query: trimmedQuery,
-      requestId,
       sessionId,
-    });
-
-    debugLog("moonmind.pipeline.plan", {
-      requestId,
-      retrieval_plan: intentPayload.retrieval_plan,
-      entities: intentPayload.entities,
-    });
-
-    const retrievalResult = await retrieveDocuments({
-      query: trimmedQuery,
-      intentPayload,
       metadata,
-      limit: 10,
-    });
-
-    const rankedDocuments = rankDocuments(retrievalResult.documents, 5);
-
-    debugLog("moonmind.pipeline.ranking", {
       requestId,
-      rankedDocuments: rankedDocuments.map((document) => ({
-        id: document.id,
-        score: document.score,
-      })),
     });
 
     debugLog("moonmind.pipeline.final_response_trigger", {
       requestId,
       documentCount: rankedDocuments.length,
+      hasStatsPayload: Boolean(statsPayload),
     });
 
     const summary = await generateResponse({
       query: trimmedQuery,
       documents: rankedDocuments,
-      intent: intentPayload.intent,
+      intent: statsPayload ? "stats_query" : intent,
+      statsPayload,
     });
 
     return {

--- a/src/moonmind/planning/queryDecomposer.js
+++ b/src/moonmind/planning/queryDecomposer.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const { createChatCompletion } = require("../adapters/openaiClient");
+const { debugLog, serializeError } = require("../utils/debug");
+const VECTOR_CONFIG = require("../../../config/vectorConfig");
+
+const DECOMPOSE_MODEL =
+  process.env.MOONMIND_DECOMPOSE_MODEL ||
+  process.env.MOONMIND_INTENT_MODEL ||
+  "gpt-4o-mini";
+
+function buildMessages(query, maxSubqueries) {
+  const systemPrompt = [
+    "You split a user question into independent, self-contained sub-questions",
+    "for a retrieval system, so each distinct information need can be searched",
+    "separately.",
+    "RULES:",
+    `- Return at most ${maxSubqueries} sub-questions.`,
+    "- If the question asks about only ONE thing, return it unchanged as the",
+    "  single sub-question (do NOT invent extra parts).",
+    "- Each sub-question must be standalone and keyword-rich (resolve pronouns).",
+    '- Return STRICT JSON: {"subqueries": ["...", "..."]}. No prose.',
+  ].join(" ");
+
+  return [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: query },
+  ];
+}
+
+function normalizeSubqueries(raw, originalQuery, maxSubqueries) {
+  if (!Array.isArray(raw)) {
+    return [originalQuery];
+  }
+
+  const cleaned = [
+    ...new Set(
+      raw
+        .filter((item) => typeof item === "string")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0),
+    ),
+  ].slice(0, maxSubqueries);
+
+  return cleaned.length > 0 ? cleaned : [originalQuery];
+}
+
+// Returns an array of sub-queries. For single-topic prompts this is just
+// [query], letting the caller take the normal single-query path. Best-effort:
+// any failure falls back to [query].
+async function decomposeQuery({ query, requestId }) {
+  const maxSubqueries = VECTOR_CONFIG.DECOMPOSE_MAX_SUBQUERIES;
+
+  try {
+    const completion = await createChatCompletion({
+      model: DECOMPOSE_MODEL,
+      messages: buildMessages(query, maxSubqueries),
+      responseFormat: { type: "json_object" },
+      temperature: 0,
+    });
+
+    const content = completion?.choices?.[0]?.message?.content;
+    const parsed = content ? JSON.parse(content) : null;
+    const subqueries = normalizeSubqueries(
+      parsed?.subqueries,
+      query,
+      maxSubqueries,
+    );
+
+    debugLog("moonmind.decompose.result", {
+      requestId,
+      subqueryCount: subqueries.length,
+      subqueries,
+    });
+
+    return subqueries;
+  } catch (error) {
+    debugLog("moonmind.decompose.error", {
+      requestId,
+      error: serializeError(error),
+    });
+    return [query];
+  }
+}
+
+module.exports = {
+  decomposeQuery,
+};

--- a/src/moonmind/ranker.js
+++ b/src/moonmind/ranker.js
@@ -1,39 +1,34 @@
 const { debugLog } = require("./utils/debug");
+const VECTOR_CONFIG = require("../../config/vectorConfig");
 
-function clampScore(value) {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  if (value < 0) {
-    return 0;
-  }
-
-  if (value > 1) {
-    return 1;
-  }
-
-  return value;
+function toScore(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function rankDocuments(documents = [], limit = 5) {
-  const ranked = [...documents]
-    .map((document) => {
-      const semanticScore = clampScore(document.semantic_score ?? 0);
-      const keywordScore = clampScore(document.keyword_match ?? 0);
-      const metadataScore = clampScore(document.metadata_match ?? 0);
+// Documents arrive already fused by Reciprocal Rank Fusion (see ranking/rrf.js),
+// each carrying `rrf_score` (fused rank signal) and `semantic_score` (raw Atlas
+// cosine score). Ranking is therefore: optionally gate on absolute semantic
+// similarity, then order by the fused score, then take the top N.
+function rankDocuments(documents = [], limit = 5, options = {}) {
+  const minSemanticScore =
+    typeof options.minSemanticScore === "number"
+      ? options.minSemanticScore
+      : VECTOR_CONFIG.MIN_SEMANTIC_SCORE;
 
-      return {
-        ...document,
-        score: Number(
-          (
-            semanticScore * 0.5 +
-            keywordScore * 0.3 +
-            metadataScore * 0.2
-          ).toFixed(6),
-        ),
-      };
-    })
+  const gated =
+    minSemanticScore > 0
+      ? documents.filter(
+          (document) => toScore(document.semantic_score) >= minSemanticScore,
+        )
+      : documents;
+
+  const ranked = [...gated]
+    .map((document) => ({
+      ...document,
+      // Surface the fused score as `score` for downstream logging / API output.
+      score: toScore(document.rrf_score),
+    }))
     .sort((left, right) => {
       if ((right.score ?? 0) !== (left.score ?? 0)) {
         return (right.score ?? 0) - (left.score ?? 0);
@@ -45,13 +40,14 @@ function rankDocuments(documents = [], limit = 5) {
 
   debugLog("moonmind.ranker.scored", {
     inputCount: documents.length,
+    gatedCount: gated.length,
+    minSemanticScore,
     returnedCount: ranked.length,
     ranked: ranked.map((document) => ({
       id: document.id,
       score: document.score,
-      semantic: clampScore(document.semantic_score ?? 0),
-      keyword: clampScore(document.keyword_match ?? 0),
-      metadata: clampScore(document.metadata_match ?? 0),
+      semantic_score: toScore(document.semantic_score),
+      sources: document.retrieval_sources || {},
     })),
   });
 

--- a/src/moonmind/ranking/llmReranker.js
+++ b/src/moonmind/ranking/llmReranker.js
@@ -1,0 +1,115 @@
+"use strict";
+
+const { createChatCompletion } = require("../adapters/openaiClient");
+const { debugLog, serializeError } = require("../utils/debug");
+const VECTOR_CONFIG = require("../../../config/vectorConfig");
+
+const RERANK_MODEL =
+  process.env.MOONMIND_RERANK_MODEL ||
+  process.env.MOONMIND_RESPONSE_MODEL ||
+  "gpt-4o-mini";
+
+const MAX_CONTENT_CHARS = 900;
+
+function truncate(value, max = MAX_CONTENT_CHARS) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function buildCandidateView(documents) {
+  return documents.map((document, index) => ({
+    index,
+    title: document.title || "Untitled",
+    content: truncate(document.content_full || document.summary_for_embedding),
+    tags: Array.isArray(document.tags) ? document.tags.slice(0, 12) : [],
+  }));
+}
+
+function buildMessages(query, candidates) {
+  const systemPrompt = [
+    "You are a precise relevance ranker for a retrieval system.",
+    "Given a user query and a numbered list of candidate documents, order the",
+    "candidates from most to least relevant to answering the query.",
+    "Only use the provided content. Do not invent documents.",
+    'Return STRICT JSON: {"order": [<candidate index>, ...]} listing every',
+    "candidate index exactly once, best first. No prose, no extra keys.",
+  ].join(" ");
+
+  return [
+    { role: "system", content: systemPrompt },
+    {
+      role: "user",
+      content: JSON.stringify({ query, candidates }, null, 2),
+    },
+  ];
+}
+
+function parseOrder(content, count) {
+  const parsed = JSON.parse(content);
+  const order = Array.isArray(parsed?.order) ? parsed.order : null;
+  if (!order) {
+    return null;
+  }
+
+  const seen = new Set();
+  const cleaned = [];
+  order.forEach((value) => {
+    const index = Number(value);
+    if (Number.isInteger(index) && index >= 0 && index < count && !seen.has(index)) {
+      seen.add(index);
+      cleaned.push(index);
+    }
+  });
+
+  // Append any candidates the model dropped so nothing is silently lost.
+  for (let index = 0; index < count; index += 1) {
+    if (!seen.has(index)) {
+      cleaned.push(index);
+    }
+  }
+
+  return cleaned;
+}
+
+// Second-stage LLM rerank over the top fused candidates. Best-effort: on any
+// failure it returns the input order (sliced), so retrieval never breaks.
+async function rerankDocuments({ query, documents, limit = 5 }) {
+  if (!Array.isArray(documents) || documents.length <= 1) {
+    return Array.isArray(documents) ? documents.slice(0, limit) : [];
+  }
+
+  const candidatePool = documents.slice(0, VECTOR_CONFIG.RERANK_CANDIDATES);
+
+  try {
+    const completion = await createChatCompletion({
+      model: RERANK_MODEL,
+      messages: buildMessages(query, buildCandidateView(candidatePool)),
+      responseFormat: { type: "json_object" },
+      temperature: 0,
+    });
+
+    const content = completion?.choices?.[0]?.message?.content;
+    const order = content ? parseOrder(content, candidatePool.length) : null;
+
+    if (!order) {
+      debugLog("moonmind.rerank.fallback", { reason: "unparseable_order" });
+      return candidatePool.slice(0, limit);
+    }
+
+    const reordered = order.map((index) => candidatePool[index]);
+    debugLog("moonmind.rerank.success", {
+      candidateCount: candidatePool.length,
+      returnedCount: Math.min(limit, reordered.length),
+    });
+    return reordered.slice(0, limit);
+  } catch (error) {
+    debugLog("moonmind.rerank.error", { error: serializeError(error) });
+    return candidatePool.slice(0, limit);
+  }
+}
+
+module.exports = {
+  rerankDocuments,
+};

--- a/src/moonmind/ranking/rrf.js
+++ b/src/moonmind/ranking/rrf.js
@@ -1,0 +1,81 @@
+"use strict";
+
+// Reciprocal Rank Fusion (RRF).
+//
+// Replaces the previous position-based score fabrication (keyword/metadata
+// "scores" derived from list index and blended with fixed weights). RRF fuses
+// several ordered result lists using only each document's *rank within its own
+// arm*, which is a legitimate signal, and is robust when the arms produce
+// scores on incomparable scales (Atlas cosine score vs. a Mongo filter match).
+//
+//   rrf_score(doc) = Σ_arm  weight_arm * 1 / (k + rank_arm(doc))
+//
+// The raw semantic score (Atlas vectorSearchScore) is carried through untouched
+// so a downstream threshold gate can still reason about absolute similarity.
+
+const DEFAULT_RRF_K = 60;
+
+function fuseByRRF(resultSets = [], options = {}) {
+  const { k = DEFAULT_RRF_K, weights = {} } = options;
+  const fused = new Map();
+
+  resultSets.forEach((resultSet) => {
+    if (!resultSet || !Array.isArray(resultSet.documents)) {
+      return;
+    }
+
+    const { source, documents } = resultSet;
+    const weight =
+      typeof weights[source] === "number" ? weights[source] : 1;
+
+    documents.forEach((document, index) => {
+      if (document == null || document.id == null) {
+        return;
+      }
+
+      const id = String(document.id);
+      const rank = index + 1;
+      const contribution = weight * (1 / (k + rank));
+
+      const existing = fused.get(id) || {
+        document,
+        rrf_score: 0,
+        semantic_score: 0,
+        retrieval_sources: {},
+      };
+
+      existing.rrf_score += contribution;
+      existing.retrieval_sources[source] = rank;
+
+      if (source === "semantic") {
+        const rawScore = Number(document.score);
+        if (Number.isFinite(rawScore)) {
+          existing.semantic_score = Math.max(
+            existing.semantic_score,
+            rawScore,
+          );
+        }
+      }
+
+      // Prefer whichever representation actually carries the full content, so a
+      // metadata-only hit doesn't shadow the richer semantic-arm document.
+      if (!existing.document.content_full && document.content_full) {
+        existing.document = document;
+      }
+
+      fused.set(id, existing);
+    });
+  });
+
+  return Array.from(fused.values()).map((entry) => ({
+    ...entry.document,
+    semantic_score: entry.semantic_score,
+    retrieval_sources: entry.retrieval_sources,
+    rrf_score: Number(entry.rrf_score.toFixed(8)),
+  }));
+}
+
+module.exports = {
+  DEFAULT_RRF_K,
+  fuseByRRF,
+};

--- a/src/moonmind/retrieval/vectorSearch.js
+++ b/src/moonmind/retrieval/vectorSearch.js
@@ -47,7 +47,7 @@ async function vectorSearch(query, limit = 5) {
           index: VECTOR_INDEX,
           queryVector: embedding,
           path: VECTOR_FIELD,
-          numCandidates: Math.max(limit * 5, 25),
+          numCandidates: Math.max(limit * 5, VECTOR_CONFIG.VECTOR_NUM_CANDIDATES),
           limit,
         },
       },

--- a/src/moonmind/retrievalEngine.js
+++ b/src/moonmind/retrievalEngine.js
@@ -1,7 +1,16 @@
 const { connectToDatabase } = require("../../mongo");
 const { vectorSearch } = require("./retrieval/vectorSearch");
+const { fuseByRRF } = require("./ranking/rrf");
 const { debugLog } = require("./utils/debug");
 const VECTOR_CONFIG = require("../../config/vectorConfig");
+
+// Per-arm weights for RRF. The metadata arm is a broad filter match rather than
+// a relevance ranking, so it contributes at a reduced weight.
+const RRF_WEIGHTS = Object.freeze({
+  semantic: 1,
+  keyword: 1,
+  metadata: 0.5,
+});
 
 // Use the same collection the write path (vectorMemoryService) persists to,
 // so read and write can never diverge on the default.
@@ -209,47 +218,6 @@ async function runMongoQuery(query, limit) {
   return results.map(normalizeDocument);
 }
 
-function mergeDocuments(resultSets) {
-  const merged = new Map();
-
-  resultSets.forEach(({ source, documents }) => {
-    documents.forEach((document, index) => {
-      const id = String(document.id);
-      const existing = merged.get(id) || {
-        ...normalizeDocument(document),
-        semantic_score: 0,
-        keyword_match: 0,
-        metadata_match: 0,
-      };
-
-      if (source === "semantic") {
-        existing.semantic_score = Math.max(
-          existing.semantic_score,
-          Number(document.score) || Math.max(0, 1 - index * 0.1),
-        );
-      }
-
-      if (source === "keyword") {
-        existing.keyword_match = Math.max(
-          existing.keyword_match,
-          Math.max(0.2, 1 - index * 0.1),
-        );
-      }
-
-      if (source === "metadata") {
-        existing.metadata_match = Math.max(
-          existing.metadata_match,
-          Math.max(0.3, 1 - index * 0.1),
-        );
-      }
-
-      merged.set(id, existing);
-    });
-  });
-
-  return Array.from(merged.values());
-}
-
 async function retrieveDocuments({
   query,
   intentPayload,
@@ -270,7 +238,13 @@ async function retrieveDocuments({
 
   if (retrievalPlan.semantic) {
     tasks.push(
-      vectorSearch(query, Math.max(limit, 10)).then((documents) => {
+      vectorSearch(query, Math.max(limit, 10)).then((rawDocuments) => {
+        // Normalize like the other arms, but preserve the raw Atlas score so
+        // RRF can carry semantic_score through for the threshold gate.
+        const documents = rawDocuments.map((document) => ({
+          ...normalizeDocument(document),
+          score: Number(document.score),
+        }));
         debugLog("moonmind.retrieval.strategy.result", {
           source: "semantic",
           count: documents.length,
@@ -311,7 +285,10 @@ async function retrieveDocuments({
   }
 
   const settled = await Promise.all(tasks);
-  const documents = mergeDocuments(settled);
+  const documents = fuseByRRF(settled, {
+    k: VECTOR_CONFIG.RRF_K,
+    weights: RRF_WEIGHTS,
+  });
 
   debugLog("moonmind.retrieval.complete", {
     query,

--- a/src/moonmind/statsRouter.js
+++ b/src/moonmind/statsRouter.js
@@ -1,9 +1,15 @@
+// Portfolio-intent trigger words. If a stats query ALSO contains any of these,
+// it is a mixed prompt (e.g. "my github stats and my projects") and must not
+// short-circuit retrieval — the pipeline should answer with stats AND docs.
+const PORTFOLIO_INTENT_PATTERN =
+  /\b(skills?|tech\s*stack|projects?|experiences?|work|role|certifications?|certificates?|education|degree|university|college|achievements?|awards?|research|papers?|publications?|hobbies?|interests?|about\s+(?:me|him|ayan)|who\s+is|tell\s+me\s+about)\b/i;
+
 function detectStatsQuery(prompt) {
   const normalizedPrompt =
     typeof prompt === "string" ? prompt.toLowerCase().trim() : "";
 
   if (!normalizedPrompt) {
-    return { isGithub: false, isLeetcode: false };
+    return { isGithub: false, isLeetcode: false, isPureStats: false };
   }
 
   const hasGithubKeyword = normalizedPrompt.includes("github");
@@ -14,9 +20,19 @@ function detectStatsQuery(prompt) {
     normalizedPrompt.includes("moonman") ||
     normalizedPrompt.includes("ayan");
 
+  const isGithub = hasGithubKeyword && hasStatsIntent;
+  const isLeetcode = hasLeetcodeKeyword && hasStatsIntent;
+
+  // Pure stats = a stats query with no additional portfolio intent, so it is
+  // safe to bypass retrieval entirely.
+  const isPureStats =
+    (isGithub || isLeetcode) &&
+    !PORTFOLIO_INTENT_PATTERN.test(normalizedPrompt);
+
   return {
-    isGithub: hasGithubKeyword && hasStatsIntent,
-    isLeetcode: hasLeetcodeKeyword && hasStatsIntent,
+    isGithub,
+    isLeetcode,
+    isPureStats,
   };
 }
 

--- a/test/ranker.test.js
+++ b/test/ranker.test.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { rankDocuments } = require("../src/moonmind/ranker");
+
+test("orders by rrf_score descending and respects limit", () => {
+  const docs = [
+    { id: "a", rrf_score: 0.01, semantic_score: 0.7 },
+    { id: "b", rrf_score: 0.03, semantic_score: 0.7 },
+    { id: "c", rrf_score: 0.02, semantic_score: 0.7 },
+  ];
+  const ranked = rankDocuments(docs, 2);
+  assert.deepEqual(ranked.map((d) => d.id), ["b", "c"]);
+  assert.equal(ranked[0].score, 0.03);
+});
+
+test("semantic threshold gate drops weak matches", () => {
+  const docs = [
+    { id: "a", rrf_score: 0.05, semantic_score: 0.4 },
+    { id: "b", rrf_score: 0.02, semantic_score: 0.75 },
+  ];
+  const ranked = rankDocuments(docs, 5, { minSemanticScore: 0.6 });
+  assert.deepEqual(ranked.map((d) => d.id), ["b"]);
+});
+
+test("gate of 0 keeps everything", () => {
+  const docs = [
+    { id: "a", rrf_score: 0.05, semantic_score: 0 },
+    { id: "b", rrf_score: 0.02, semantic_score: 0 },
+  ];
+  const ranked = rankDocuments(docs, 5, { minSemanticScore: 0 });
+  assert.equal(ranked.length, 2);
+});
+
+test("deterministic id tie-break on equal scores", () => {
+  const docs = [
+    { id: "z", rrf_score: 0.02, semantic_score: 0.7 },
+    { id: "a", rrf_score: 0.02, semantic_score: 0.7 },
+  ];
+  const ranked = rankDocuments(docs, 5);
+  assert.deepEqual(ranked.map((d) => d.id), ["a", "z"]);
+});

--- a/test/rrf.test.js
+++ b/test/rrf.test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { fuseByRRF } = require("../src/moonmind/ranking/rrf");
+
+test("a document appearing in multiple arms outranks a single-arm document", () => {
+  const resultSets = [
+    { source: "semantic", documents: [{ id: "a", score: 0.9 }, { id: "b", score: 0.8 }] },
+    { source: "metadata", documents: [{ id: "b" }, { id: "c" }] },
+  ];
+
+  const fused = fuseByRRF(resultSets, { k: 60, weights: { semantic: 1, metadata: 1 } });
+  const byId = Object.fromEntries(fused.map((d) => [d.id, d]));
+
+  // b is in both arms, a only in semantic -> b should score higher than a.
+  assert.ok(byId.b.rrf_score > byId.a.rrf_score);
+  assert.equal(fused.length, 3);
+});
+
+test("raw semantic score is carried through as semantic_score", () => {
+  const fused = fuseByRRF([
+    { source: "semantic", documents: [{ id: "a", score: 0.77 }] },
+  ]);
+  assert.equal(fused[0].semantic_score, 0.77);
+});
+
+test("metadata-only docs get zero semantic_score", () => {
+  const fused = fuseByRRF([
+    { source: "metadata", documents: [{ id: "x" }] },
+  ]);
+  assert.equal(fused[0].semantic_score, 0);
+});
+
+test("per-arm weights scale contribution", () => {
+  const high = fuseByRRF([{ source: "semantic", documents: [{ id: "a" }] }], {
+    weights: { semantic: 1 },
+  });
+  const low = fuseByRRF([{ source: "semantic", documents: [{ id: "a" }] }], {
+    weights: { semantic: 0.5 },
+  });
+  assert.ok(high[0].rrf_score > low[0].rrf_score);
+});
+
+test("richer content representation wins on dedupe", () => {
+  const fused = fuseByRRF([
+    { source: "metadata", documents: [{ id: "a", title: "thin" }] },
+    { source: "semantic", documents: [{ id: "a", title: "rich", content_full: "details" }] },
+  ]);
+  assert.equal(fused[0].content_full, "details");
+});

--- a/utils/embeddingGenerator.js
+++ b/utils/embeddingGenerator.js
@@ -24,6 +24,27 @@ function generateDeterministicSummary(document) {
   ].join(" ");
 }
 
+// Build the text that is actually embedded. Previously only
+// `summary_for_embedding` was vectorized — and when auto-generated that is
+// metadata boilerplate, so vectors encoded structure rather than substance.
+// We now embed title + tags + the real `content_full` when it exists, falling
+// back to the summary. The human-facing `summary_for_embedding` field is left
+// untouched for display.
+function buildEmbeddingInput(document = {}) {
+  const title = typeof document.title === "string" ? document.title.trim() : "";
+  const tags = Array.isArray(document.tags)
+    ? document.tags.filter((tag) => typeof tag === "string" && tag.trim())
+    : [];
+  const content =
+    typeof document.content_full === "string" && document.content_full.trim()
+      ? document.content_full.trim()
+      : document.summary_for_embedding || "";
+
+  return [title, tags.length ? `Tags: ${tags.join(", ")}` : "", content]
+    .filter(Boolean)
+    .join("\n");
+}
+
 async function generateEmbeddingVector(summaryText) {
   const response = await createEmbedding({
     model: VECTOR_CONFIG.EMBEDDING_MODEL,
@@ -42,5 +63,6 @@ async function generateEmbeddingVector(summaryText) {
 
 module.exports = {
   generateDeterministicSummary,
+  buildEmbeddingInput,
   generateEmbeddingVector,
 };

--- a/validators/memoryValidator.js
+++ b/validators/memoryValidator.js
@@ -96,6 +96,19 @@ function assertSummaryConstraints(document) {
   if (!document.summary_for_embedding) {
     return;
   }
+
+  // The sentence-range guard exists to keep the *embedded* text substantial.
+  // Retrieval now embeds content_full when present (utils/embeddingGenerator.js
+  // buildEmbeddingInput), so summary_for_embedding is only the embedding source
+  // when content_full is empty. When content_full is provided the summary is a
+  // display-only field, so we don't constrain its shape.
+  const hasContentFull =
+    typeof document.content_full === "string" &&
+    document.content_full.trim().length > 0;
+  if (hasContentFull) {
+    return;
+  }
+
   const sentenceCount = countSentences(document.summary_for_embedding);
   if (
     sentenceCount < VECTOR_CONFIG.SUMMARY_MIN_SENTENCES ||


### PR DESCRIPTION


- Replace position-based score fabrication with Reciprocal Rank Fusion (RRF) for robust multi-arm ranking (semantic + keyword + metadata)
- Add semantic score threshold gate (configurable via MOONMIND_MIN_SEMANTIC_SCORE) so weak matches drop and "no matching documents" path fires honestly
- Embed content_full instead of metadata boilerplate for higher retrieval recall
- Fix stats-router shadowing: mixed prompts ("github stats and projects") now retrieve both stats and docs instead of bypassing retrieval
- Raise vector ANN candidates (50→150, MOONMIND_VECTOR_NUM_CANDIDATES)
- Add LLM reranker and query decomposition modules (feature-flagged off by default)
- Improve summary validation: only enforce sentence range when content_full absent
- Fix .env loading in backfill/eval scripts to work from any directory
- Add retrieval quality eval harness (scripts/eval/retrievalEval.js + goldset template)
- Add re-embed backfill script (scripts/reembed.js) for existing documents
- Add unit tests for RRF and ranker modules (9/9 pass)